### PR TITLE
Implementación de búsqueda y guardado de mazos públicos

### DIFF
--- a/backend/src/main/java/com/magicvs/backend/controller/DeckController.java
+++ b/backend/src/main/java/com/magicvs/backend/controller/DeckController.java
@@ -71,6 +71,11 @@ public ResponseEntity<DeckResponseDTO> createDeck(
         return ResponseEntity.ok(deckService.getUserDecks(userId));
     }
 
+    @GetMapping("/public")
+    public ResponseEntity<List<DeckSummaryDTO>> getPublicDecks() {
+        return ResponseEntity.ok(deckService.getPublicDecks());
+    }
+
     @DeleteMapping("/{deckId}")
     public ResponseEntity<Void> deleteDeck(
         @PathVariable Long deckId,

--- a/backend/src/main/java/com/magicvs/backend/dto/DeckSummaryDTO.java
+++ b/backend/src/main/java/com/magicvs/backend/dto/DeckSummaryDTO.java
@@ -99,4 +99,14 @@ public class DeckSummaryDTO {
     public void setAverageCmc(Double averageCmc) {
         this.averageCmc = averageCmc;
     }
+
+    private List<String> colorIdentity;
+
+    public List<String> getColorIdentity() {
+        return colorIdentity;
+    }
+
+    public void setColorIdentity(List<String> colorIdentity) {
+        this.colorIdentity = colorIdentity;
+    }
 }

--- a/backend/src/main/java/com/magicvs/backend/dto/DeckSummaryDTO.java
+++ b/backend/src/main/java/com/magicvs/backend/dto/DeckSummaryDTO.java
@@ -1,6 +1,7 @@
 package com.magicvs.backend.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class DeckSummaryDTO {
 
@@ -11,6 +12,8 @@ public class DeckSummaryDTO {
     private LocalDateTime updatedAt;
     private Boolean isPublic;
     private String mainImageUrl;
+    private List<String> cardNames;
+    private Double averageCmc;
 
     public DeckSummaryDTO() {
     }
@@ -79,5 +82,21 @@ public class DeckSummaryDTO {
 
     public void setMainImageUrl(String mainImageUrl) {
         this.mainImageUrl = mainImageUrl;
+    }
+
+    public List<String> getCardNames() {
+        return cardNames;
+    }
+
+    public void setCardNames(List<String> cardNames) {
+        this.cardNames = cardNames;
+    }
+
+    public Double getAverageCmc() {
+        return averageCmc;
+    }
+
+    public void setAverageCmc(Double averageCmc) {
+        this.averageCmc = averageCmc;
     }
 }

--- a/backend/src/main/java/com/magicvs/backend/repository/DeckRepository.java
+++ b/backend/src/main/java/com/magicvs/backend/repository/DeckRepository.java
@@ -15,6 +15,9 @@ public interface DeckRepository extends JpaRepository<Deck, Long> {
     @Query("SELECT d FROM Deck d LEFT JOIN FETCH d.cards c LEFT JOIN FETCH c.card WHERE d.id = :deckId")
     java.util.Optional<Deck> findByIdWithCards(@Param("deckId") Long deckId);
 
+    @Query("SELECT d FROM Deck d LEFT JOIN FETCH d.cards c LEFT JOIN FETCH c.card WHERE d.isPublic = true ORDER BY d.updatedAt DESC")
+    List<Deck> findPublicDecksOrderByUpdatedAtDesc();
+
     boolean existsByIdAndUserId(Long deckId, Long userId);
 
     long countByUserId(Long userId);

--- a/backend/src/main/java/com/magicvs/backend/service/DeckService.java
+++ b/backend/src/main/java/com/magicvs/backend/service/DeckService.java
@@ -367,7 +367,15 @@ public DeckResponseDTO copyDeck(Long deckId, String authorization) {
 
         if (deck.getCards() != null && !deck.getCards().isEmpty()) {
             List<String> cardNames = deck.getCards().stream()
-                .map(dc -> dc.getCard().getName())
+                .flatMap(dc -> {
+                    List<String> names = new ArrayList<>();
+                    names.add(dc.getCard().getName());
+                    String printed = extractPrintedName(dc.getCard().getRawJson());
+                    if (printed != null && !printed.isBlank() && !printed.equals(dc.getCard().getName())) {
+                        names.add(printed);
+                    }
+                    return names.stream();
+                })
                 .collect(Collectors.toList());
             dto.setCardNames(cardNames);
 
@@ -397,7 +405,33 @@ public DeckResponseDTO copyDeck(Long deckId, String authorization) {
             dto.setAverageCmc(0.0);
         }
 
+        dto.setColorIdentity(buildColorIdentity(deck));
         return dto;
+    }
+
+    private static final Pattern PRINTED_NAME_PATTERN = Pattern.compile("\"printed_name\"\\s*:\\s*\"([^\"]+)\"");
+
+    private String extractPrintedName(String rawJson) {
+        if (rawJson == null || rawJson.isBlank()) return null;
+        Matcher m = PRINTED_NAME_PATTERN.matcher(rawJson);
+        return m.find() ? m.group(1) : null;
+    }
+
+    private static final List<String> WUBRG_ORDER = java.util.Arrays.asList("W", "U", "B", "R", "G");
+
+    private List<String> buildColorIdentity(Deck deck) {
+        if (deck.getCards() == null || deck.getCards().isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        java.util.Set<String> colors = new java.util.HashSet<>();
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("\"([WUBRG])\"");
+        for (com.magicvs.backend.model.DeckCard dc : deck.getCards()) {
+            String json = dc.getCard().getColorIdentityJson();
+            if (json == null || json.isBlank()) continue;
+            java.util.regex.Matcher m = pattern.matcher(json);
+            while (m.find()) colors.add(m.group(1));
+        }
+        return WUBRG_ORDER.stream().filter(colors::contains).collect(Collectors.toList());
     }
 
     private String getBestArtCrop(Deck deck) {

--- a/backend/src/main/java/com/magicvs/backend/service/DeckService.java
+++ b/backend/src/main/java/com/magicvs/backend/service/DeckService.java
@@ -179,6 +179,13 @@ public DeckResponseDTO createDeck(String authorization, CreateDeckDTO deckDTO) {
             .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public List<DeckSummaryDTO> getPublicDecks() {
+        return deckRepository.findPublicDecksOrderByUpdatedAtDesc().stream()
+            .map(this::toDeckSummary)
+            .collect(Collectors.toList());
+    }
+
     /**
      * Elimina un mazo (solo el propietario)
      */
@@ -348,7 +355,7 @@ public DeckResponseDTO copyDeck(Long deckId, String authorization) {
     }
 
     private DeckSummaryDTO toDeckSummary(Deck deck) {
-        return new DeckSummaryDTO(
+        DeckSummaryDTO dto = new DeckSummaryDTO(
             deck.getId(),
             deck.getName(),
             deck.getFormat() != null ? deck.getFormat().name() : DeckFormat.STANDARD.name(),
@@ -357,6 +364,40 @@ public DeckResponseDTO copyDeck(Long deckId, String authorization) {
             deck.getPublic(),
             getBestArtCrop(deck)
         );
+
+        if (deck.getCards() != null && !deck.getCards().isEmpty()) {
+            List<String> cardNames = deck.getCards().stream()
+                .map(dc -> dc.getCard().getName())
+                .collect(Collectors.toList());
+            dto.setCardNames(cardNames);
+
+            // Exclude lands from CMC average (lands have CMC 0 and would distort results)
+            List<com.magicvs.backend.model.DeckCard> spells = deck.getCards().stream()
+                .filter(dc -> {
+                    String typeLine = dc.getCard().getTypeLine();
+                    return typeLine == null
+                        || (!typeLine.toLowerCase().contains("land")
+                            && !typeLine.toLowerCase().contains("tierra"));
+                })
+                .collect(Collectors.toList());
+
+            double totalCmc = spells.stream()
+                .mapToDouble(dc -> {
+                    double cmc = dc.getCard().getCmc() != null ? dc.getCard().getCmc().doubleValue() : 0.0;
+                    int qty = dc.getQuantity() != null ? dc.getQuantity() : 1;
+                    return cmc * qty;
+                })
+                .sum();
+            int totalSpells = spells.stream()
+                .mapToInt(dc -> dc.getQuantity() != null ? dc.getQuantity() : 1)
+                .sum();
+            dto.setAverageCmc(totalSpells > 0 ? totalCmc / totalSpells : 0.0);
+        } else {
+            dto.setCardNames(java.util.Collections.emptyList());
+            dto.setAverageCmc(0.0);
+        }
+
+        return dto;
     }
 
     private String getBestArtCrop(Deck deck) {

--- a/frontend/src/app/core/services/deck-builder.service.ts
+++ b/frontend/src/app/core/services/deck-builder.service.ts
@@ -314,16 +314,19 @@ export class DeckBuilderService {
    */
   getDeckById(deckId: number): Observable<any> {
     const token = localStorage.getItem('token') || localStorage.getItem('authToken') || '';
-    const headers = new HttpHeaders({
-      'Authorization': `Bearer ${token}`
-    });
-
+    const headers = token
+      ? new HttpHeaders({ 'Authorization': `Bearer ${token}` })
+      : new HttpHeaders();
     return this.http.get(`${this.apiUrl}/${deckId}`, { headers });
   }
 
   isBasicLandType(typeLine: string): boolean {
     return (typeLine || '').toLowerCase().includes('basic land');
   }
+  getPublicDecks(): Observable<any> {
+    return this.http.get(`${this.apiUrl}/public`);
+  }
+
   /**
    * Copia un mazo de otro usuario
    */

--- a/frontend/src/app/features/deck-builder/deck-builder-page.component.ts
+++ b/frontend/src/app/features/deck-builder/deck-builder-page.component.ts
@@ -5,11 +5,12 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DeckBuilderService, Card, DeckCard } from '../../core/services/deck-builder.service';
 import { DeckSearchPanelComponent } from './deck-search-panel.component';
+import { PublicDecksModalComponent } from './public-decks-modal.component';
 
 @Component({
   selector: 'app-deck-builder-page',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterModule, DeckSearchPanelComponent],
+  imports: [CommonModule, FormsModule, RouterModule, DeckSearchPanelComponent, PublicDecksModalComponent],
   templateUrl: './deck-builder-page.html',
   styleUrls: ['./deck-builder-page.scss']
 })
@@ -36,6 +37,7 @@ export class DeckBuilderPageComponent {
   loadingDeck = false;
   notificationMessage: string | null = null;
   notificationType: 'success' | 'error' | 'info' = 'success';
+  showPublicDecksModal = false;
   private notificationTimer?: number;
   private flippedDeckCardIds = new Set<number>();
 
@@ -302,6 +304,19 @@ export class DeckBuilderPageComponent {
 
     return 'Otros';
   }
+  openPublicDecksModal(): void {
+    this.showPublicDecksModal = true;
+  }
+
+  closePublicDecksModal(): void {
+    this.showPublicDecksModal = false;
+  }
+
+  onPublicDeckCopied(event: { deckId: number; deckName: string }): void {
+    this.showPublicDecksModal = false;
+    this.showNotification(`"${event.deckName}" guardado en tus mazos.`, 'success');
+  }
+
   copyCurrentDeck(): void {
     if (!this.editingDeckId) return;
 

--- a/frontend/src/app/features/deck-builder/deck-builder-page.html
+++ b/frontend/src/app/features/deck-builder/deck-builder-page.html
@@ -12,12 +12,12 @@
       <div class="flex items-center gap-3">
         <button
           (click)="openPublicDecksModal()"
-          class="flex items-center gap-2 rounded-2xl border border-secondary/40 bg-secondary/10 px-4 py-2.5 text-sm font-semibold text-secondary transition hover:bg-secondary/20"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064" />
-          </svg>
-          Mazos Públicos
+            class="flex items-center gap-2 rounded-2xl border border-secondary/40 bg-secondary/10 px-4 py-2.5 text-base font-semibold text-blue-500 transition hover:bg-secondary/20"
+            >
+          <span class="material-symbols-outlined text-lg text-blue-400">
+             public
+          </span>
+         Explorar Mazos Públicos
         </button>
         <div class="rounded-2xl border border-outline-variant/60 bg-surface/70 px-4 py-3 text-right">
           <div class="text-xs uppercase tracking-[0.16em] text-on-surface/60">Formato</div>

--- a/frontend/src/app/features/deck-builder/deck-builder-page.html
+++ b/frontend/src/app/features/deck-builder/deck-builder-page.html
@@ -9,10 +9,21 @@
         </p>
       </div>
 
-      <div class="rounded-2xl border border-outline-variant/60 bg-surface/70 px-4 py-3 text-right">
-        <div class="text-xs uppercase tracking-[0.16em] text-on-surface/60">Formato</div>
-        <div class="mt-1 font-headline text-lg font-semibold text-primary">{{ deckFormatLabel }}</div>
-        <div class="mt-1 text-[11px] uppercase tracking-[0.16em] text-on-surface/55">{{ modeLabel }}</div>
+      <div class="flex items-center gap-3">
+        <button
+          (click)="openPublicDecksModal()"
+          class="flex items-center gap-2 rounded-2xl border border-secondary/40 bg-secondary/10 px-4 py-2.5 text-sm font-semibold text-secondary transition hover:bg-secondary/20"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064" />
+          </svg>
+          Mazos Públicos
+        </button>
+        <div class="rounded-2xl border border-outline-variant/60 bg-surface/70 px-4 py-3 text-right">
+          <div class="text-xs uppercase tracking-[0.16em] text-on-surface/60">Formato</div>
+          <div class="mt-1 font-headline text-lg font-semibold text-primary">{{ deckFormatLabel }}</div>
+          <div class="mt-1 text-[11px] uppercase tracking-[0.16em] text-on-surface/55">{{ modeLabel }}</div>
+        </div>
       </div>
     </header>
 
@@ -225,9 +236,15 @@
       </aside>
 
       <main class="min-w-0">
-        <!-- Si queréis centralizar glassmorphism, podéis mover estas clases a utilidades globales del design system -->
         <app-deck-search-panel (cardSelected)="onCardSelected($event)"></app-deck-search-panel>
       </main>
     </div>
   </div>
 </div>
+
+@if (showPublicDecksModal) {
+  <app-public-decks-modal
+    (close)="closePublicDecksModal()"
+    (deckCopied)="onPublicDeckCopied($event)"
+  ></app-public-decks-modal>
+}

--- a/frontend/src/app/features/deck-builder/public-decks-modal.component.ts
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.component.ts
@@ -151,14 +151,29 @@ export class PublicDecksModalComponent implements OnInit {
     C: 'border-slate-400 bg-slate-400/15 text-slate-200 shadow-[0_0_10px_rgba(148,163,184,0.3)]',
   };
 
-  private static readonly MANA_PIP_CLASS: Record<string, string> = {
-    W: 'bg-amber-300/80 text-amber-900',
-    U: 'bg-sky-400/80 text-sky-900',
-    B: 'bg-violet-400/80 text-white',
-    R: 'bg-rose-400/80 text-white',
-    G: 'bg-emerald-400/80 text-emerald-900',
-    C: 'bg-slate-400/80 text-white',
+  private static readonly MANA_BUTTON_BASE: Record<string, string> = {
+    W: 'bg-slate-100 border-slate-300',
+    U: 'bg-blue-600 border-blue-500',
+    B: 'bg-neutral-900 border-neutral-700',
+    R: 'bg-red-600 border-red-500',
+    G: 'bg-emerald-600 border-emerald-500',
   };
+
+  private static readonly MANA_PIP_CLASS: Record<string, string> = {
+    W: 'bg-slate-100 border-slate-300',
+    U: 'bg-blue-600 border-blue-500',
+    B: 'bg-neutral-900 border-neutral-700',
+    R: 'bg-red-600 border-red-500',
+    G: 'bg-emerald-600 border-emerald-500',
+    C: 'bg-slate-400 border-slate-500',
+  };
+
+  getManaButtonClass(color: string): string {
+    const base = PublicDecksModalComponent.MANA_BUTTON_BASE[color] ?? 'bg-surface-container border-outline-variant';
+    return this.activeColors().includes(color)
+      ? `${base} scale-125 opacity-100 shadow-md`
+      : `${base} opacity-40 hover:opacity-85`;
+  }
 
   getManaActiveClass(color: string): string {
     return PublicDecksModalComponent.MANA_ACTIVE_CLASS[color] ?? '';

--- a/frontend/src/app/features/deck-builder/public-decks-modal.component.ts
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.component.ts
@@ -3,6 +3,11 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DeckBuilderService } from '../../core/services/deck-builder.service';
 
+function sortDecksAlpha(a: { name: string; averageCmc: number }, b: { name: string; averageCmc: number }): number {
+  const nameCompare = a.name.localeCompare(b.name, 'es', { sensitivity: 'base' });
+  return nameCompare !== 0 ? nameCompare : (a.averageCmc || 0) - (b.averageCmc || 0);
+}
+
 interface PublicDeck {
   id: number;
   name: string;
@@ -13,6 +18,7 @@ interface PublicDeck {
   mainImageUrl: string | null;
   cardNames: string[];
   averageCmc: number;
+  colorIdentity: string[];
 }
 
 interface PreviewCard {
@@ -55,6 +61,7 @@ export class PublicDecksModalComponent implements OnInit {
   searchQuery = signal('');
   copyingId = signal<number | null>(null);
   copiedIds = signal<Set<number>>(new Set());
+  activeColors = signal<string[]>([]);
 
   selectedDeck = signal<PublicDeck | null>(null);
   previewData = signal<PreviewDeck | null>(null);
@@ -66,13 +73,21 @@ export class PublicDecksModalComponent implements OnInit {
 
   readonly filteredDecks = computed(() => {
     const q = this.searchQuery().toLowerCase().trim();
-    if (!q) return this.decks();
+    const colors = this.activeColors();
 
-    const isLow  = PublicDecksModalComponent.LOW_MANA_KEYWORDS.some(k => q.includes(k));
-    const isHigh = PublicDecksModalComponent.HIGH_MANA_KEYWORDS.some(k => q.includes(k));
-    const isMid  = PublicDecksModalComponent.MID_MANA_KEYWORDS.some(k => q.includes(k));
+    const isLow  = !!q && PublicDecksModalComponent.LOW_MANA_KEYWORDS.some(k => q.includes(k));
+    const isHigh = !!q && PublicDecksModalComponent.HIGH_MANA_KEYWORDS.some(k => q.includes(k));
+    const isMid  = !!q && PublicDecksModalComponent.MID_MANA_KEYWORDS.some(k => q.includes(k));
 
     return this.decks().filter(deck => {
+      // Color filter: colorless decks always shown; otherwise all selected colors must be present (AND)
+      if (colors.length > 0) {
+        const deckColors = deck.colorIdentity ?? [];
+        if (deckColors.length > 0 && !colors.every(c => deckColors.includes(c))) return false;
+      }
+
+      if (!q) return true;
+
       const cmc = deck.averageCmc ?? 0;
       if (isLow)  return cmc <= 2.0;
       if (isHigh) return cmc >= 3.5;
@@ -81,7 +96,7 @@ export class PublicDecksModalComponent implements OnInit {
       const matchesName = deck.name.toLowerCase().includes(q);
       const matchesCard = (deck.cardNames ?? []).some(cn => cn.toLowerCase().includes(q));
       return matchesName || matchesCard;
-    });
+    }).sort(sortDecksAlpha);
   });
 
   readonly manaCurveLabel = computed(() => {
@@ -110,7 +125,7 @@ export class PublicDecksModalComponent implements OnInit {
   ngOnInit(): void {
     this.deckService.getPublicDecks().subscribe({
       next: (data: PublicDeck[]) => {
-        this.decks.set(data);
+        this.decks.set([...data].sort(sortDecksAlpha));
         this.loading.set(false);
       },
       error: () => {
@@ -118,6 +133,53 @@ export class PublicDecksModalComponent implements OnInit {
         this.loading.set(false);
       }
     });
+  }
+
+
+  readonly manaColors = ['W', 'U', 'B', 'R', 'G'] as const;
+
+  private static readonly MANA_LABEL: Record<string, string> = {
+    W: 'Blanco', U: 'Azul', B: 'Negro', R: 'Rojo', G: 'Verde'
+  };
+
+  private static readonly MANA_ACTIVE_CLASS: Record<string, string> = {
+    W: 'border-amber-300 bg-amber-300/15 text-amber-200 shadow-[0_0_10px_rgba(251,191,36,0.3)]',
+    U: 'border-sky-400 bg-sky-400/15 text-sky-200 shadow-[0_0_10px_rgba(56,189,248,0.3)]',
+    B: 'border-violet-400 bg-violet-400/15 text-violet-200 shadow-[0_0_10px_rgba(167,139,250,0.3)]',
+    R: 'border-rose-400 bg-rose-400/15 text-rose-200 shadow-[0_0_10px_rgba(251,113,133,0.3)]',
+    G: 'border-emerald-400 bg-emerald-400/15 text-emerald-200 shadow-[0_0_10px_rgba(52,211,153,0.3)]',
+    C: 'border-slate-400 bg-slate-400/15 text-slate-200 shadow-[0_0_10px_rgba(148,163,184,0.3)]',
+  };
+
+  private static readonly MANA_PIP_CLASS: Record<string, string> = {
+    W: 'bg-amber-300/80 text-amber-900',
+    U: 'bg-sky-400/80 text-sky-900',
+    B: 'bg-violet-400/80 text-white',
+    R: 'bg-rose-400/80 text-white',
+    G: 'bg-emerald-400/80 text-emerald-900',
+    C: 'bg-slate-400/80 text-white',
+  };
+
+  getManaActiveClass(color: string): string {
+    return PublicDecksModalComponent.MANA_ACTIVE_CLASS[color] ?? '';
+  }
+
+  getManaPipClass(color: string): string {
+    return PublicDecksModalComponent.MANA_PIP_CLASS[color] ?? '';
+  }
+
+  getManaTitle(color: string): string {
+    return PublicDecksModalComponent.MANA_LABEL[color] ?? color;
+  }
+
+  toggleColor(color: string): void {
+    this.activeColors.update(current =>
+      current.includes(color) ? current.filter(c => c !== color) : [...current, color]
+    );
+  }
+
+  clearColors(): void {
+    this.activeColors.set([]);
   }
 
   onSearchChange(value: string): void {

--- a/frontend/src/app/features/deck-builder/public-decks-modal.component.ts
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.component.ts
@@ -59,6 +59,7 @@ export class PublicDecksModalComponent implements OnInit {
   loadError = signal<string | null>(null);
   copyError = signal<string | null>(null);
   searchQuery = signal('');
+  manaFilter = signal<'low' | 'mid' | 'high' | null>(null);
   copyingId = signal<number | null>(null);
   copiedIds = signal<Set<number>>(new Set());
   activeColors = signal<string[]>([]);
@@ -67,31 +68,23 @@ export class PublicDecksModalComponent implements OnInit {
   previewData = signal<PreviewDeck | null>(null);
   loadingPreview = signal(false);
 
-  private static readonly LOW_MANA_KEYWORDS  = ['poco maná', 'poco mana', 'bajo maná', 'bajo mana', 'bajo coste', 'aggro', 'rapido', 'rápido', 'low mana', 'low cost'];
-  private static readonly HIGH_MANA_KEYWORDS = ['mucho maná', 'mucho mana', 'alto maná', 'alto mana', 'alto coste', 'control', 'lento', 'high mana', 'high cost'];
-  private static readonly MID_MANA_KEYWORDS  = ['midrange', 'medio maná', 'medio mana', 'mid mana'];
-
   readonly filteredDecks = computed(() => {
     const q = this.searchQuery().toLowerCase().trim();
     const colors = this.activeColors();
-
-    const isLow  = !!q && PublicDecksModalComponent.LOW_MANA_KEYWORDS.some(k => q.includes(k));
-    const isHigh = !!q && PublicDecksModalComponent.HIGH_MANA_KEYWORDS.some(k => q.includes(k));
-    const isMid  = !!q && PublicDecksModalComponent.MID_MANA_KEYWORDS.some(k => q.includes(k));
+    const mana = this.manaFilter();
 
     return this.decks().filter(deck => {
-      // Color filter: colorless decks always shown; otherwise all selected colors must be present (AND)
       if (colors.length > 0) {
         const deckColors = deck.colorIdentity ?? [];
         if (deckColors.length > 0 && !colors.every(c => deckColors.includes(c))) return false;
       }
 
-      if (!q) return true;
-
       const cmc = deck.averageCmc ?? 0;
-      if (isLow)  return cmc <= 2.0;
-      if (isHigh) return cmc >= 3.5;
-      if (isMid)  return cmc > 2.0 && cmc < 3.5;
+      if (mana === 'low'  && cmc > 2.0)  return false;
+      if (mana === 'high' && cmc < 3.5)  return false;
+      if (mana === 'mid'  && (cmc <= 2.0 || cmc >= 3.5)) return false;
+
+      if (!q) return true;
 
       const matchesName = deck.name.toLowerCase().includes(q);
       const matchesCard = (deck.cardNames ?? []).some(cn => cn.toLowerCase().includes(q));
@@ -199,6 +192,11 @@ export class PublicDecksModalComponent implements OnInit {
 
   onSearchChange(value: string): void {
     this.searchQuery.set(value);
+  }
+
+  setManaFilter(filter: 'low' | 'mid' | 'high' | null): void {
+    this.manaFilter.set(this.manaFilter() === filter ? null : filter);
+    
   }
 
   selectDeck(deck: PublicDeck): void {

--- a/frontend/src/app/features/deck-builder/public-decks-modal.component.ts
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.component.ts
@@ -1,0 +1,206 @@
+import { Component, EventEmitter, inject, OnInit, Output, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DeckBuilderService } from '../../core/services/deck-builder.service';
+
+interface PublicDeck {
+  id: number;
+  name: string;
+  format: string;
+  totalCards: number;
+  updatedAt: string;
+  isPublic: boolean;
+  mainImageUrl: string | null;
+  cardNames: string[];
+  averageCmc: number;
+}
+
+interface PreviewCard {
+  cardId: number;
+  cardName: string;
+  cardImage: string;
+  backCardImage?: string;
+  doubleFaced?: boolean;
+  manaCost: string;
+  cardType: string;
+  quantity: number;
+}
+
+interface PreviewDeck {
+  id: number;
+  name: string;
+  description: string;
+  format: string;
+  totalCards: number;
+  cards: PreviewCard[];
+}
+
+@Component({
+  selector: 'app-public-decks-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './public-decks-modal.html',
+  styleUrls: ['./public-decks-modal.scss']
+})
+export class PublicDecksModalComponent implements OnInit {
+  @Output() close = new EventEmitter<void>();
+  @Output() deckCopied = new EventEmitter<{ deckId: number; deckName: string }>();
+
+  private deckService = inject(DeckBuilderService);
+
+  decks = signal<PublicDeck[]>([]);
+  loading = signal(true);
+  loadError = signal<string | null>(null);
+  copyError = signal<string | null>(null);
+  searchQuery = signal('');
+  copyingId = signal<number | null>(null);
+  copiedIds = signal<Set<number>>(new Set());
+
+  selectedDeck = signal<PublicDeck | null>(null);
+  previewData = signal<PreviewDeck | null>(null);
+  loadingPreview = signal(false);
+
+  private static readonly LOW_MANA_KEYWORDS  = ['poco maná', 'poco mana', 'bajo maná', 'bajo mana', 'bajo coste', 'aggro', 'rapido', 'rápido', 'low mana', 'low cost'];
+  private static readonly HIGH_MANA_KEYWORDS = ['mucho maná', 'mucho mana', 'alto maná', 'alto mana', 'alto coste', 'control', 'lento', 'high mana', 'high cost'];
+  private static readonly MID_MANA_KEYWORDS  = ['midrange', 'medio maná', 'medio mana', 'mid mana'];
+
+  readonly filteredDecks = computed(() => {
+    const q = this.searchQuery().toLowerCase().trim();
+    if (!q) return this.decks();
+
+    const isLow  = PublicDecksModalComponent.LOW_MANA_KEYWORDS.some(k => q.includes(k));
+    const isHigh = PublicDecksModalComponent.HIGH_MANA_KEYWORDS.some(k => q.includes(k));
+    const isMid  = PublicDecksModalComponent.MID_MANA_KEYWORDS.some(k => q.includes(k));
+
+    return this.decks().filter(deck => {
+      const cmc = deck.averageCmc ?? 0;
+      if (isLow)  return cmc <= 2.0;
+      if (isHigh) return cmc >= 3.5;
+      if (isMid)  return cmc > 2.0 && cmc < 3.5;
+
+      const matchesName = deck.name.toLowerCase().includes(q);
+      const matchesCard = (deck.cardNames ?? []).some(cn => cn.toLowerCase().includes(q));
+      return matchesName || matchesCard;
+    });
+  });
+
+  readonly manaCurveLabel = computed(() => {
+    const deck = this.selectedDeck();
+    if (!deck) return '';
+    const cmc = deck.averageCmc ?? 0;
+    if (cmc <= 2.0)  return 'Aggro (bajo maná)';
+    if (cmc >= 3.5)  return 'Control (alto maná)';
+    return 'Midrange';
+  });
+
+  readonly groupedPreviewCards = computed(() => {
+    const data = this.previewData();
+    if (!data) return [];
+    const groups = new Map<string, PreviewCard[]>();
+    data.cards.forEach(card => {
+      const g = this.resolveTypeGroup(card.cardType);
+      if (!groups.has(g)) groups.set(g, []);
+      groups.get(g)!.push(card);
+    });
+    return Array.from(groups.entries())
+      .map(([group, cards]) => ({ group, cards: cards.sort((a, b) => a.cardName.localeCompare(b.cardName)) }))
+      .sort((a, b) => a.group.localeCompare(b.group));
+  });
+
+  ngOnInit(): void {
+    this.deckService.getPublicDecks().subscribe({
+      next: (data: PublicDeck[]) => {
+        this.decks.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loadError.set('No se pudieron cargar los mazos públicos.');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  onSearchChange(value: string): void {
+    this.searchQuery.set(value);
+  }
+
+  selectDeck(deck: PublicDeck): void {
+    if (this.selectedDeck()?.id === deck.id) return;
+    this.selectedDeck.set(deck);
+    this.loadPreview(deck.id);
+  }
+
+  retryPreview(): void {
+    const deck = this.selectedDeck();
+    if (deck) this.loadPreview(deck.id);
+  }
+
+  private loadPreview(deckId: number): void {
+    this.previewData.set(null);
+    this.loadingPreview.set(true);
+
+    this.deckService.getDeckById(deckId).subscribe({
+      next: (data: PreviewDeck) => {
+        this.previewData.set(data);
+        this.loadingPreview.set(false);
+      },
+      error: () => {
+        this.loadingPreview.set(false);
+      }
+    });
+  }
+
+  copyDeck(deck: PublicDeck): void {
+    if (this.copyingId() !== null) return;
+    this.copyingId.set(deck.id);
+    this.copyError.set(null);
+
+    this.deckService.copyDeck(deck.id).subscribe({
+      next: () => {
+        this.copiedIds.update(ids => new Set([...ids, deck.id]));
+        this.copyingId.set(null);
+        this.deckCopied.emit({ deckId: deck.id, deckName: deck.name });
+      },
+      error: (err) => {
+        this.copyingId.set(null);
+        this.copyError.set(
+          err.status === 401 ? 'Debes iniciar sesión para guardar mazos' : 'Error al guardar el mazo'
+        );
+      }
+    });
+  }
+
+  isCopied(deckId: number): boolean {
+    return this.copiedIds().has(deckId);
+  }
+
+  getManaLabel(cmc: number): string {
+    if (cmc <= 2.0) return 'Bajo';
+    if (cmc >= 3.5) return 'Alto';
+    return 'Medio';
+  }
+
+  getManaClass(cmc: number): string {
+    if (cmc <= 2.0) return 'text-emerald-300 border-emerald-400/40 bg-emerald-500/10';
+    if (cmc >= 3.5) return 'text-rose-300 border-rose-400/40 bg-rose-500/10';
+    return 'text-amber-300 border-amber-400/40 bg-amber-500/10';
+  }
+
+  onBackdropClick(event: MouseEvent): void {
+    if ((event.target as HTMLElement).classList.contains('modal-backdrop')) {
+      this.close.emit();
+    }
+  }
+
+  private resolveTypeGroup(typeLine: string): string {
+    const n = (typeLine || '').toLowerCase();
+    if (n.includes('creature') || n.includes('criatura')) return 'Criaturas';
+    if (n.includes('instant') || n.includes('instantáneo')) return 'Instantáneos';
+    if (n.includes('sorcery') || n.includes('conjuro')) return 'Conjuros';
+    if (n.includes('enchantment') || n.includes('encantamiento')) return 'Encantamientos';
+    if (n.includes('artifact') || n.includes('artefacto')) return 'Artefactos';
+    if (n.includes('planeswalker')) return 'Planeswalkers';
+    if (n.includes('land') || n.includes('tierra')) return 'Tierras';
+    return 'Otros';
+  }
+}

--- a/frontend/src/app/features/deck-builder/public-decks-modal.html
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.html
@@ -33,15 +33,15 @@
           type="text"
           [value]="searchQuery()"
           (input)="onSearchChange($any($event.target).value)"
-          placeholder='Nombre de mazo o de una carta que este en el mazo, o maná (p.ej. "poco maná", "midrange", "mucho maná")'
+          placeholder="Nombre del mazo o de una carta que esté en él"
           class="w-full rounded-xl border border-outline-variant bg-surface/80 py-2.5 pl-9 pr-4 text-sm text-on-surface outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/30"
         />
       </div>
-      <!-- Color filter + mana keyword chips -->
+      <!-- Color filter + mana curve filters -->
       <div class="mt-2.5 flex flex-wrap items-center gap-x-4 gap-y-2">
         <p class="mt-0.5 text-sm text-on-surface/65">Tipo de maná: </p>
 
-        <!-- Color buttons (MTG pip style, igual que /profile Identidad) -->
+        <!-- Color buttons (MTG pip style) -->
         <div class="flex items-center gap-2">
           @for (color of manaColors; track color) {
             <button
@@ -64,20 +64,32 @@
 
         <!-- Mana curve quick-filters -->
         <div class="flex flex-wrap gap-1.5">
-          <button (click)="onSearchChange('poco maná')"
-            class="rounded-full border border-emerald-400 bg-emerald-500/10 px-2.5 py-0.5 text-[10px] font-medium text-emerald-300 transition hover:opacity-80">
+          <button (click)="setManaFilter('low')"
+            class="rounded-full border px-2.5 py-0.5 text-[10px] font-medium transition hover:opacity-80"
+            [class.border-emerald-400]="true"
+            [class.text-emerald-300]="true"
+            [class.bg-emerald-500/25]="manaFilter() === 'low'"
+            [class.bg-emerald-500/10]="manaFilter() !== 'low'">
             Poco maná
           </button>
-          <button (click)="onSearchChange('midrange')"
-            class="rounded-full border border-amber-400 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-medium text-amber-300 transition hover:opacity-80">
+          <button (click)="setManaFilter('mid')"
+            class="rounded-full border px-2.5 py-0.5 text-[10px] font-medium transition hover:opacity-80"
+            [class.border-amber-400]="true"
+            [class.text-amber-300]="true"
+            [class.bg-amber-500/25]="manaFilter() === 'mid'"
+            [class.bg-amber-500/10]="manaFilter() !== 'mid'">
             Midrange
           </button>
-          <button (click)="onSearchChange('mucho maná')"
-            class="rounded-full border border-rose-400 bg-rose-500/10 px-2.5 py-0.5 text-[10px] font-medium text-rose-300 transition hover:opacity-80">
+          <button (click)="setManaFilter('high')"
+            class="rounded-full border px-2.5 py-0.5 text-[10px] font-medium transition hover:opacity-80"
+            [class.border-rose-400]="true"
+            [class.text-rose-300]="true"
+            [class.bg-rose-500/25]="manaFilter() === 'high'"
+            [class.bg-rose-500/10]="manaFilter() !== 'high'">
             Mucho maná
           </button>
-          @if (searchQuery()) {
-            <button (click)="onSearchChange('')"
+          @if (manaFilter()) {
+            <button (click)="setManaFilter(null)"
               class="rounded-full border border-outline-variant/50 px-2.5 py-0.5 text-[10px] text-on-surface/50 transition hover:text-on-surface">
               ✕ Quitar filtro
             </button>

--- a/frontend/src/app/features/deck-builder/public-decks-modal.html
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.html
@@ -37,26 +37,55 @@
           class="w-full rounded-xl border border-outline-variant bg-surface/80 py-2.5 pl-9 pr-4 text-sm text-on-surface outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/30"
         />
       </div>
-      <!-- Quick-filter chips -->
-      <div class="mt-2 flex flex-wrap gap-1.5">
-        <button (click)="onSearchChange('poco maná')"
-          class="rounded-full border border-emerald-400 bg-emerald-500/10 px-2.5 py-0.5 text-[10px] font-medium text-emerald-300 transition hover:opacity-80">
-          Poco maná (aggro)
-        </button>
-        <button (click)="onSearchChange('midrange')"
-          class="rounded-full border border-amber-400 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-medium text-amber-300 transition hover:opacity-80">
-          Midrange
-        </button>
-        <button (click)="onSearchChange('mucho maná')"
-          class="rounded-full border border-rose-400 bg-rose-500/10 px-2.5 py-0.5 text-[10px] font-medium text-rose-300 transition hover:opacity-80">
-          Mucho maná (control)
-        </button>
-        @if (searchQuery()) {
-          <button (click)="onSearchChange('')"
-            class="rounded-full border border-outline-variant/50 px-2.5 py-0.5 text-[10px] text-on-surface/50 transition hover:text-on-surface">
-            ✕ limpiar
+      <!-- Color filter + mana keyword chips -->
+      <div class="mt-2.5 flex flex-wrap items-center gap-x-4 gap-y-2">
+
+        <!-- Color buttons (identical style to /cartas) -->
+        <div class="flex items-center gap-1.5">
+          @for (color of manaColors; track color) {
+            <button
+              (click)="toggleColor(color)"
+              [title]="getManaTitle(color)"
+              class="flex h-8 w-8 items-center justify-center rounded-full border transition-all"
+              [class]="activeColors().includes(color)
+                ? 'border-primary bg-primary/10 shadow-[0_0_12px_rgba(142,68,173,0.3)] ' + getManaActiveClass(color)
+                : 'border-outline-variant bg-white/5 hover:border-on-surface/60'"
+            >
+              <span class="font-headline text-xs font-bold transition-transform hover:scale-110"
+                [class.text-primary]="activeColors().includes(color)">{{ color }}</span>
+            </button>
+          }
+          @if (activeColors().length > 0) {
+            <button (click)="clearColors()"
+              class="ml-1 rounded-full border border-outline-variant/50 px-2 py-0.5 text-[10px] text-on-surface/50 transition hover:text-on-surface">
+              ✕
+            </button>
+          }
+        </div>
+
+        <div class="h-4 w-px bg-outline-variant/50 hidden sm:block"></div>
+
+        <!-- Mana curve quick-filters -->
+        <div class="flex flex-wrap gap-1.5">
+          <button (click)="onSearchChange('poco maná')"
+            class="rounded-full border border-emerald-400 bg-emerald-500/10 px-2.5 py-0.5 text-[10px] font-medium text-emerald-300 transition hover:opacity-80">
+            Poco maná
           </button>
-        }
+          <button (click)="onSearchChange('midrange')"
+            class="rounded-full border border-amber-400 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-medium text-amber-300 transition hover:opacity-80">
+            Midrange
+          </button>
+          <button (click)="onSearchChange('mucho maná')"
+            class="rounded-full border border-rose-400 bg-rose-500/10 px-2.5 py-0.5 text-[10px] font-medium text-rose-300 transition hover:opacity-80">
+            Mucho maná
+          </button>
+          @if (searchQuery()) {
+            <button (click)="onSearchChange('')"
+              class="rounded-full border border-outline-variant/50 px-2.5 py-0.5 text-[10px] text-on-surface/50 transition hover:text-on-surface">
+              ✕ Quitar filtro de cantidad de maná
+            </button>
+          }
+        </div>
       </div>
     </div>
 
@@ -110,6 +139,15 @@
                           {{ getManaLabel(deck.averageCmc) }} maná
                         </span>
                       </div>
+                      <!-- Color identity pips -->
+                      @if (deck.colorIdentity.length > 0) {
+                        <div class="mt-1.5 flex gap-0.5">
+                          @for (c of deck.colorIdentity; track c) {
+                            <span class="flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold"
+                              [ngClass]="getManaPipClass(c)">{{ c }}</span>
+                          }
+                        </div>
+                      }
                     </div>
                   </div>
                   <!-- subtle "click to preview" hint when not selected -->
@@ -150,8 +188,13 @@
                     {{ selectedDeck()!.totalCards }} cartas
                   </span>
                   <span class="rounded-full border px-2.5 py-0.5 text-[11px] font-semibold" [ngClass]="getManaClass(selectedDeck()!.averageCmc)">
-                    {{ manaCurveLabel() }} · CMC medio {{ selectedDeck()!.averageCmc | number:'1.1-1' }}
+                    {{ manaCurveLabel() }} · CMC {{ selectedDeck()!.averageCmc | number:'1.1-1' }}
                   </span>
+                  <!-- Color identity pips (larger, in preview header) -->
+                  @for (c of selectedDeck()!.colorIdentity; track c) {
+                    <span class="flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold"
+                      [ngClass]="getManaPipClass(c)" [title]="getManaTitle(c)">{{ c }}</span>
+                  }
                 </div>
               </div>
 

--- a/frontend/src/app/features/deck-builder/public-decks-modal.html
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.html
@@ -33,37 +33,34 @@
           type="text"
           [value]="searchQuery()"
           (input)="onSearchChange($any($event.target).value)"
-          placeholder='Nombre, carta (ej: "Lightning Bolt") o maná ("poco maná", "control"…)'
+          placeholder='Nombre de mazo o de una carta que este en el mazo, o maná (p.ej. "poco maná", "midrange", "mucho maná")'
           class="w-full rounded-xl border border-outline-variant bg-surface/80 py-2.5 pl-9 pr-4 text-sm text-on-surface outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/30"
         />
       </div>
       <!-- Color filter + mana keyword chips -->
       <div class="mt-2.5 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <p class="mt-0.5 text-sm text-on-surface/65">Tipo de maná: </p>
 
-        <!-- Color buttons (identical style to /cartas) -->
-        <div class="flex items-center gap-1.5">
+        <!-- Color buttons (MTG pip style, igual que /profile Identidad) -->
+        <div class="flex items-center gap-2">
           @for (color of manaColors; track color) {
             <button
               (click)="toggleColor(color)"
               [title]="getManaTitle(color)"
-              class="flex h-8 w-8 items-center justify-center rounded-full border transition-all"
-              [class]="activeColors().includes(color)
-                ? 'border-primary bg-primary/10 shadow-[0_0_12px_rgba(142,68,173,0.3)] ' + getManaActiveClass(color)
-                : 'border-outline-variant bg-white/5 hover:border-on-surface/60'"
-            >
-              <span class="font-headline text-xs font-bold transition-transform hover:scale-110"
-                [class.text-primary]="activeColors().includes(color)">{{ color }}</span>
-            </button>
+              class="h-5 w-5 rounded-full border-2 transition-all duration-200 hover:scale-110"
+              [ngClass]="getManaButtonClass(color)"
+            ></button>
           }
           @if (activeColors().length > 0) {
             <button (click)="clearColors()"
               class="ml-1 rounded-full border border-outline-variant/50 px-2 py-0.5 text-[10px] text-on-surface/50 transition hover:text-on-surface">
-              ✕
+              ✕ Quitar filtro
             </button>
           }
         </div>
 
         <div class="h-4 w-px bg-outline-variant/50 hidden sm:block"></div>
+        <p class="mt-0.5 text-sm text-on-surface/65">Cantidad de maná: </p>
 
         <!-- Mana curve quick-filters -->
         <div class="flex flex-wrap gap-1.5">
@@ -82,7 +79,7 @@
           @if (searchQuery()) {
             <button (click)="onSearchChange('')"
               class="rounded-full border border-outline-variant/50 px-2.5 py-0.5 text-[10px] text-on-surface/50 transition hover:text-on-surface">
-              ✕ Quitar filtro de cantidad de maná
+              ✕ Quitar filtro
             </button>
           }
         </div>
@@ -141,10 +138,10 @@
                       </div>
                       <!-- Color identity pips -->
                       @if (deck.colorIdentity.length > 0) {
-                        <div class="mt-1.5 flex gap-0.5">
+                        <div class="mt-1.5 flex gap-1">
                           @for (c of deck.colorIdentity; track c) {
-                            <span class="flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold"
-                              [ngClass]="getManaPipClass(c)">{{ c }}</span>
+                            <span class="h-3 w-3 rounded-full border-2 inline-block"
+                              [ngClass]="getManaPipClass(c)" [title]="getManaTitle(c)"></span>
                           }
                         </div>
                       }
@@ -192,8 +189,8 @@
                   </span>
                   <!-- Color identity pips (larger, in preview header) -->
                   @for (c of selectedDeck()!.colorIdentity; track c) {
-                    <span class="flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold"
-                      [ngClass]="getManaPipClass(c)" [title]="getManaTitle(c)">{{ c }}</span>
+                    <span class="h-4 w-4 rounded-full border-2 inline-block"
+                      [ngClass]="getManaPipClass(c)" [title]="getManaTitle(c)"></span>
                   }
                 </div>
               </div>

--- a/frontend/src/app/features/deck-builder/public-decks-modal.html
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.html
@@ -1,0 +1,235 @@
+<div
+  class="modal-backdrop fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+  (click)="onBackdropClick($event)"
+>
+  <!-- overflow-hidden es imprescindible: sin él max-height no acota el flex-col y los hijos flex-1 no saben su tamaño -->
+  <div class="modal-panel relative flex h-[88vh] w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-outline-variant/70 bg-surface-container-high/95 shadow-2xl shadow-black/40 backdrop-blur-xl">
+
+    <!-- Header (fixed) -->
+    <div class="flex shrink-0 items-center justify-between border-b border-outline-variant/60 px-6 py-4">
+      <div>
+        <p class="font-headline text-xs uppercase tracking-[0.2em] text-secondary/90">Comunidad</p>
+        <h2 class="mt-1 font-headline text-2xl font-bold text-on-surface">Mazos Públicos</h2>
+        <p class="mt-0.5 text-sm text-on-surface/65">Explora, previsualiza y guarda mazos de otros jugadores</p>
+      </div>
+      <button
+        (click)="close.emit()"
+        class="rounded-xl border border-outline-variant/60 bg-surface/70 p-2 text-on-surface/70 transition hover:bg-surface hover:text-on-surface"
+        aria-label="Cerrar"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Search bar (fixed) -->
+    <div class="shrink-0 border-b border-outline-variant/60 px-6 py-3">
+      <div class="relative">
+        <svg xmlns="http://www.w3.org/2000/svg" class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-on-surface/40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        <input
+          type="text"
+          [value]="searchQuery()"
+          (input)="onSearchChange($any($event.target).value)"
+          placeholder='Nombre, carta (ej: "Lightning Bolt") o maná ("poco maná", "control"…)'
+          class="w-full rounded-xl border border-outline-variant bg-surface/80 py-2.5 pl-9 pr-4 text-sm text-on-surface outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/30"
+        />
+      </div>
+      <!-- Quick-filter chips -->
+      <div class="mt-2 flex flex-wrap gap-1.5">
+        <button (click)="onSearchChange('poco maná')"
+          class="rounded-full border border-emerald-400 bg-emerald-500/10 px-2.5 py-0.5 text-[10px] font-medium text-emerald-300 transition hover:opacity-80">
+          Poco maná (aggro)
+        </button>
+        <button (click)="onSearchChange('midrange')"
+          class="rounded-full border border-amber-400 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-medium text-amber-300 transition hover:opacity-80">
+          Midrange
+        </button>
+        <button (click)="onSearchChange('mucho maná')"
+          class="rounded-full border border-rose-400 bg-rose-500/10 px-2.5 py-0.5 text-[10px] font-medium text-rose-300 transition hover:opacity-80">
+          Mucho maná (control)
+        </button>
+        @if (searchQuery()) {
+          <button (click)="onSearchChange('')"
+            class="rounded-full border border-outline-variant/50 px-2.5 py-0.5 text-[10px] text-on-surface/50 transition hover:text-on-surface">
+            ✕ limpiar
+          </button>
+        }
+      </div>
+    </div>
+
+    <!-- Body: split layout — flex-1 + overflow-hidden para que cada columna gestione su propio scroll -->
+    <div class="flex min-h-0 flex-1 overflow-hidden">
+
+      <!-- ── LEFT: deck list (scroll independiente) ── -->
+      <div class="flex w-72 shrink-0 flex-col overflow-hidden border-r border-outline-variant/60">
+
+        @if (loadError()) {
+          <div class="m-4 rounded-2xl border border-rose-400/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">{{ loadError() }}</div>
+        }
+
+        @if (loading()) {
+          <div class="flex flex-1 items-center justify-center">
+            <div class="h-7 w-7 animate-spin rounded-full border-2 border-primary border-t-transparent"></div>
+          </div>
+        } @else if (filteredDecks().length === 0) {
+          <div class="m-4 rounded-2xl border border-dashed border-outline-variant p-6 text-center text-sm text-on-surface/65">
+            @if (searchQuery()) {
+              Sin resultados para <span class="font-semibold text-on-surface/80">"{{ searchQuery() }}"</span>
+            } @else {
+              No hay mazos públicos todavía.
+            }
+          </div>
+        } @else {
+          <!-- scrollable deck list -->
+          <div class="min-h-0 flex-1 overflow-y-auto">
+            <div class="space-y-1 p-3">
+              @for (deck of filteredDecks(); track deck.id) {
+                <button
+                  (click)="selectDeck(deck)"
+                  class="w-full rounded-2xl border p-3 text-left transition"
+                  [class.border-primary]="selectedDeck()?.id === deck.id"
+                  [class.bg-primary/10]="selectedDeck()?.id === deck.id"
+                  [class.border-outline-variant/50]="selectedDeck()?.id !== deck.id"
+                  [class.bg-surface/40]="selectedDeck()?.id !== deck.id"
+                  [class.hover:bg-surface/60]="selectedDeck()?.id !== deck.id"
+                >
+                  <div class="flex items-center gap-2.5">
+                    @if (deck.mainImageUrl) {
+                      <img [src]="deck.mainImageUrl" [alt]="deck.name" class="h-10 w-8 shrink-0 rounded-md object-cover" />
+                    } @else {
+                      <div class="flex h-10 w-8 shrink-0 items-center justify-center rounded-md bg-surface-container text-on-surface/30 text-xs">?</div>
+                    }
+                    <div class="min-w-0">
+                      <p class="truncate text-sm font-semibold text-on-surface">{{ deck.name }}</p>
+                      <div class="mt-0.5 flex flex-wrap items-center gap-1.5">
+                        <span class="text-[10px] text-on-surface/55">{{ deck.totalCards }} cartas</span>
+                        <span class="rounded-full border px-1.5 py-px text-[9px] font-semibold" [ngClass]="getManaClass(deck.averageCmc)">
+                          {{ getManaLabel(deck.averageCmc) }} maná
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- subtle "click to preview" hint when not selected -->
+                  @if (selectedDeck()?.id !== deck.id) {
+                    <p class="mt-1.5 text-[10px] text-on-surface/35">Clic para ver cartas →</p>
+                  }
+                </button>
+              }
+            </div>
+          </div>
+          <div class="shrink-0 border-t border-outline-variant/60 px-4 py-2 text-right text-[11px] text-on-surface/45">
+            {{ filteredDecks().length }} mazo{{ filteredDecks().length !== 1 ? 's' : '' }}
+          </div>
+        }
+      </div>
+
+      <!-- ── RIGHT: preview panel ── -->
+      <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
+
+        @if (!selectedDeck()) {
+          <div class="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center text-on-surface/40">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-14 w-14 opacity-20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 15l6 6m-11-4a7 7 0 110-14 7 7 0 010 14z" />
+            </svg>
+            <p class="text-sm">Selecciona un mazo de la lista<br>para ver sus cartas</p>
+          </div>
+        } @else {
+          <!-- Preview header (fixed inside right panel) -->
+          <div class="shrink-0 border-b border-outline-variant/60 p-5">
+            <div class="flex items-start justify-between gap-4">
+              <div class="min-w-0">
+                <h3 class="font-headline text-xl font-bold text-on-surface">{{ selectedDeck()!.name }}</h3>
+                <div class="mt-1.5 flex flex-wrap items-center gap-2">
+                  <span class="rounded-full border border-outline-variant/50 bg-surface-container px-2.5 py-0.5 text-[11px] uppercase tracking-wide text-on-surface/60">
+                    {{ selectedDeck()!.format }}
+                  </span>
+                  <span class="rounded-full border border-outline-variant/50 bg-surface-container px-2.5 py-0.5 text-[11px] text-on-surface/60">
+                    {{ selectedDeck()!.totalCards }} cartas
+                  </span>
+                  <span class="rounded-full border px-2.5 py-0.5 text-[11px] font-semibold" [ngClass]="getManaClass(selectedDeck()!.averageCmc)">
+                    {{ manaCurveLabel() }} · CMC medio {{ selectedDeck()!.averageCmc | number:'1.1-1' }}
+                  </span>
+                </div>
+              </div>
+
+              <div class="shrink-0 flex flex-col items-end gap-1.5">
+                <button
+                  (click)="copyDeck(selectedDeck()!)"
+                  [disabled]="copyingId() !== null || isCopied(selectedDeck()!.id)"
+                  class="rounded-xl px-4 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60"
+                  [class.bg-primary]="!isCopied(selectedDeck()!.id)"
+                  [class.text-on-primary]="!isCopied(selectedDeck()!.id)"
+                  [class.hover:brightness-110]="!isCopied(selectedDeck()!.id)"
+                  [class.bg-emerald-600]="isCopied(selectedDeck()!.id)"
+                  [class.text-white]="isCopied(selectedDeck()!.id)"
+                >
+                  @if (copyingId() === selectedDeck()!.id) { Guardando... }
+                  @else if (isCopied(selectedDeck()!.id)) { ✓ Guardado }
+                  @else { Guardar en mis mazos }
+                </button>
+                @if (copyError()) {
+                  <p class="text-xs text-rose-300">{{ copyError() }}</p>
+                }
+              </div>
+            </div>
+          </div>
+
+          <!-- Card grid (scrollable) -->
+          <div class="min-h-0 flex-1 overflow-y-auto p-5">
+            @if (loadingPreview()) {
+              <div class="flex items-center justify-center py-16">
+                <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent"></div>
+                <span class="ml-3 text-sm text-on-surface/65">Cargando cartas...</span>
+              </div>
+            } @else if (!previewData()) {
+              <div class="flex flex-col items-center gap-2 py-12 text-center text-on-surface/50">
+                <p class="text-sm">No se pudieron cargar las cartas de este mazo.</p>
+                <button (click)="retryPreview()" class="mt-2 rounded-xl border border-outline-variant px-3 py-1.5 text-xs transition hover:bg-surface">
+                  Reintentar
+                </button>
+              </div>
+            } @else {
+              <div class="space-y-6">
+                @for (group of groupedPreviewCards(); track group.group) {
+                  <section>
+                    <h4 class="mb-3 font-headline text-xs font-semibold uppercase tracking-[0.14em] text-on-surface/55">
+                      {{ group.group }}
+                      <span class="ml-1 text-on-surface/35">({{ group.cards.length }})</span>
+                    </h4>
+                    <div class="grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-5">
+                      @for (card of group.cards; track card.cardId) {
+                        <div class="group relative overflow-hidden rounded-xl border border-outline-variant/50 bg-surface/60 transition hover:border-outline-variant hover:bg-surface">
+                          <!-- Card image -->
+                          <div class="relative aspect-[5/7] w-full overflow-hidden bg-surface-container">
+                            <img
+                              [src]="card.cardImage"
+                              [alt]="card.cardName"
+                              class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                              loading="lazy"
+                            />
+                            <!-- Quantity badge -->
+                            <div class="absolute right-1.5 top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-black/70 font-headline text-[11px] font-bold text-white shadow">
+                              {{ card.quantity }}
+                            </div>
+                          </div>
+                          <!-- Card name + cost -->
+                          <div class="px-1.5 py-1">
+                            <p class="truncate text-[10px] font-semibold leading-tight text-on-surface">{{ card.cardName }}</p>
+                            <p class="truncate text-[9px] text-on-surface/45">{{ card.manaCost || '—' }}</p>
+                          </div>
+                        </div>
+                      }
+                    </div>
+                  </section>
+                }
+              </div>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/deck-builder/public-decks-modal.scss
+++ b/frontend/src/app/features/deck-builder/public-decks-modal.scss
@@ -1,0 +1,21 @@
+.modal-backdrop {
+  animation: fade-in 0.15s ease-out;
+}
+
+.modal-panel {
+  animation: slide-up 0.2s ease-out;
+}
+
+.deck-list-col {
+  min-height: 0;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}


### PR DESCRIPTION
En esta issue se ha implementado en el apartado de 'mazos' un botón donde poder ver mazos públicos de todos los usuarios de la app y la posibilidad de guardarlos en los mazos propios del usuario.

<img width="1828" height="790" alt="image" src="https://github.com/user-attachments/assets/9d22cc68-493f-48a9-bf3d-32a21a877964" />

Pulsando el botón, se abre una pestaña donde ver, buscar, y filtrar todos los mazos públicos de la app. Aparecen ordenador alfabéticamente y, antes de guardar el mazo, aparece una visualización de las cartas que este tiene.

<img width="1365" height="824" alt="image" src="https://github.com/user-attachments/assets/b1af6315-b38d-414b-8ff6-6926d50ae375" />


Closes #141 