### PR TITLE
Especteo de batallas y pequeño arreglo smtp

### DIFF
--- a/backend/src/main/java/com/magicvs/backend/controller/MatchController.java
+++ b/backend/src/main/java/com/magicvs/backend/controller/MatchController.java
@@ -16,10 +16,19 @@ public class MatchController {
 
     private final MatchService matchService;
     private final AuthService authService;
+    private final com.magicvs.backend.service.BattleService battleService;
+    private final com.magicvs.backend.repository.FriendshipRepository friendshipRepository;
+    private final com.magicvs.backend.repository.RegistroRepository registroRepository;
 
-    public MatchController(MatchService matchService, AuthService authService) {
+    public MatchController(MatchService matchService, AuthService authService,
+                           com.magicvs.backend.service.BattleService battleService,
+                           com.magicvs.backend.repository.FriendshipRepository friendshipRepository,
+                           com.magicvs.backend.repository.RegistroRepository registroRepository) {
         this.matchService = matchService;
         this.authService = authService;
+        this.battleService = battleService;
+        this.friendshipRepository = friendshipRepository;
+        this.registroRepository = registroRepository;
     }
 
     @GetMapping("/history")
@@ -29,5 +38,39 @@ public class MatchController {
         
         List<MatchHistoryDto> history = matchService.getHistoryForUser(userId);
         return ResponseEntity.ok(history);
+    }
+
+    @GetMapping("/friends/active")
+    public ResponseEntity<List<MatchHistoryDto>> getActiveFriendsMatches(@RequestHeader("Authorization") String token) {
+        Long userId = authService.getUserId(token.replace("Bearer ", ""))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token"));
+        
+        List<MatchHistoryDto> activeMatches = matchService.getActiveMatchesForFriends(userId);
+        return ResponseEntity.ok(activeMatches);
+    }
+
+    @GetMapping("/{id}/spectate")
+    public ResponseEntity<com.magicvs.backend.service.BattleService.GameState> spectateMatch(
+            @RequestHeader("Authorization") String token,
+            @PathVariable Long id,
+            @RequestParam Long friendId) {
+            
+        Long userId = authService.getUserId(token.replace("Bearer ", ""))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token"));
+                
+        com.magicvs.backend.model.User user = registroRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        com.magicvs.backend.model.User friend = registroRepository.findById(friendId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Friend not found"));
+
+        if (!friendshipRepository.existsByUserAndFriend(user, friend) && !friendshipRepository.existsByUserAndFriend(friend, user)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not friends with this user");
+        }
+
+        com.magicvs.backend.service.BattleService.GameState state = battleService.getSpectatorState(userId, id, friendId);
+        if (state == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(state);
     }
 }

--- a/backend/src/main/java/com/magicvs/backend/repository/FriendshipRepository.java
+++ b/backend/src/main/java/com/magicvs/backend/repository/FriendshipRepository.java
@@ -18,10 +18,10 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query("SELECT f FROM Friendship f WHERE (f.user = :u1 AND f.friend = :u2) OR (f.user = :u2 AND f.friend = :u1)")
     Optional<Friendship> findByUsers(@Param("u1") User u1, @Param("u2") User u2);
 
-    @Query("SELECT f FROM Friendship f WHERE f.friend = :user AND f.status = 'PENDING'")
+    @Query("SELECT f FROM Friendship f WHERE f.friend = :user AND f.status = com.magicvs.backend.model.FriendshipStatus.PENDING")
     List<Friendship> findPendingRequestsForUser(@Param("user") User user);
 
-    @Query("SELECT f FROM Friendship f WHERE (f.user = :user OR f.friend = :user) AND f.status = 'ACCEPTED'")
+    @Query("SELECT f FROM Friendship f WHERE (f.user = :user OR f.friend = :user) AND f.status = com.magicvs.backend.model.FriendshipStatus.ACCEPTED")
     List<Friendship> findAcceptedFriendsForUser(@Param("user") User user);
 
     boolean existsByUserAndFriend(User user, User friend);

--- a/backend/src/main/java/com/magicvs/backend/repository/MatchRepository.java
+++ b/backend/src/main/java/com/magicvs/backend/repository/MatchRepository.java
@@ -21,4 +21,7 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 
     @Query("SELECT m FROM Match m WHERE (m.player1 = :user OR m.player2 = :user) AND m.status = com.magicvs.backend.model.MatchStatus.FINISHED AND m.finishedAt >= :start AND m.finishedAt < :end ORDER BY m.finishedAt ASC")
     List<Match> findFinishedByUserInDateRange(@Param("user") User user, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    @Query("SELECT m FROM Match m WHERE (m.player1.id IN :friendIds OR m.player2.id IN :friendIds) AND m.status = com.magicvs.backend.model.MatchStatus.LIVE ORDER BY m.createdAt DESC")
+    List<Match> findActiveMatchesByFriendIds(@Param("friendIds") List<Long> friendIds);
 }

--- a/backend/src/main/java/com/magicvs/backend/service/BattleService.java
+++ b/backend/src/main/java/com/magicvs/backend/service/BattleService.java
@@ -242,6 +242,45 @@ public class BattleService {
         }
     }
 
+    public GameState getSpectatorState(Long userId, Long matchId, Long friendId) {
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new RuntimeException("Match not found"));
+        
+        GameState state = getGameState(matchId);
+        if (state == null) return null;
+        
+        // Determinar quién es el amigo en el estado (player1 o player2)
+        String friendIdStr = friendId.toString();
+        
+        if (state.getPlayer1() != null && !state.getPlayer1().getId().equals(friendIdStr)) {
+            // Player1 NO es el amigo, ocultar su mano
+            for (CardState card : state.getPlayer1().getHand()) {
+                hideCard(card);
+            }
+        }
+        
+        if (state.getPlayer2() != null && !state.getPlayer2().getId().equals(friendIdStr)) {
+            // Player2 NO es el amigo, ocultar su mano
+            for (CardState card : state.getPlayer2().getHand()) {
+                hideCard(card);
+            }
+        }
+        
+        return state;
+    }
+
+    private void hideCard(CardState card) {
+        card.setCardId(null);
+        card.setName("Unknown Card");
+        card.setImageUrl("https://static.wikia.nocookie.net/mtgsalvation_gamepedia/images/f/f8/Magic_card_back.jpg");
+        card.setType("Unknown");
+        card.setOracleText("");
+        card.setManaCost(new ArrayList<>());
+        card.setPower("");
+        card.setToughness("");
+        card.setProducedMana(new ArrayList<>());
+    }
+
     // --- CLASES DTO / INNER CLASSES ---
 
     @Data

--- a/backend/src/main/java/com/magicvs/backend/service/MatchService.java
+++ b/backend/src/main/java/com/magicvs/backend/service/MatchService.java
@@ -23,13 +23,16 @@ public class MatchService {
     private final RegistroRepository userRepository;
     private final UserDailyStatsRepository dailyStatsRepository;
     private final AchievementService achievementService;
+    private final com.magicvs.backend.repository.FriendshipRepository friendshipRepository;
 
     public MatchService(MatchRepository matchRepository, RegistroRepository userRepository,
-            UserDailyStatsRepository dailyStatsRepository, AchievementService achievementService) {
+            UserDailyStatsRepository dailyStatsRepository, AchievementService achievementService,
+            com.magicvs.backend.repository.FriendshipRepository friendshipRepository) {
         this.matchRepository = matchRepository;
         this.userRepository = userRepository;
         this.dailyStatsRepository = dailyStatsRepository;
         this.achievementService = achievementService;
+        this.friendshipRepository = friendshipRepository;
     }
 
     public List<MatchHistoryDto> getHistoryForUser(Long userId) {
@@ -40,6 +43,25 @@ public class MatchService {
                 .map(m -> mapToDto(m, userId))
                 .collect(Collectors.toList());
     }
+
+    public List<MatchHistoryDto> getActiveMatchesForFriends(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        List<com.magicvs.backend.model.Friendship> friends = friendshipRepository.findAcceptedFriendsForUser(user);
+        
+        List<Long> friendIds = friends.stream()
+            .map(f -> f.getUser().getId().equals(userId) ? f.getFriend().getId() : f.getUser().getId())
+            .collect(Collectors.toList());
+            
+        if (friendIds.isEmpty()) {
+            return List.of();
+        }
+        
+        List<Match> matches = matchRepository.findActiveMatchesByFriendIds(friendIds);
+        return matches.stream()
+                .map(m -> mapToDto(m, userId))
+                .collect(Collectors.toList());
+    }
+
 
     private MatchHistoryDto mapToDto(Match match, Long currentUserId) {
         MatchHistoryDto dto = new MatchHistoryDto();

--- a/backend/src/main/java/com/magicvs/backend/service/PasswordResetService.java
+++ b/backend/src/main/java/com/magicvs/backend/service/PasswordResetService.java
@@ -54,6 +54,7 @@ public class PasswordResetService {
     }
 
     private void sendResetTokenEmail(User user, String token) {
+        String resetUrl = "http://localhost:4200/reset-password/" + token;
         try {
             String fromAddress = System.getenv("SMTP_FROM") != null ? System.getenv("SMTP_FROM") : "noreply@magicvs.local";
             MimeMessage mimeMessage = mailSender.createMimeMessage();
@@ -62,8 +63,6 @@ public class PasswordResetService {
             helper.setTo(user.getEmail());
             helper.setFrom(fromAddress);
             helper.setSubject("🔑 Recupera tu acceso a MagicVS");
-
-            String resetUrl = "http://localhost:4200/reset-password/" + token;
 
             String htmlContent = "<!DOCTYPE html><html><head>" +
                     "<meta charset='UTF-8'><meta name='viewport' content='width=device-width, initial-scale=1.0'>" +

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,15 +15,16 @@ spring.jpa.properties.hibernate.order_updates=true
 
 server.port=${PORT:8080}
 
-# SMTP settings (set SMTP_USER and SMTP_PASS in environment for credentials)
-spring.mail.host=smtp.gmail.com
-spring.mail.port=587
+# SMTP settings (configurable via environment variables)
+spring.mail.host=${SMTP_HOST:smtp-relay.brevo.com}
+spring.mail.port=${SMTP_PORT:587}
 spring.mail.username=${SMTP_USER:}
 spring.mail.password=${SMTP_PASS:}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.debug=true
-spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
+# Trust the configured host dynamically instead of hardcoding smtp.gmail.com
+spring.mail.properties.mail.smtp.ssl.trust=${SMTP_HOST:smtp-relay.brevo.com}
 
 # Reporte Diario de Actividad
 app.daily-report.cron=0 30 14 * * ?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,10 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/magicvs
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: postgres
-      SMTP_USER: "noreplymagicvs@gmail.com"
-      SMTP_PASS: "qhxmzwbsoozavefg"
+      SMTP_HOST: "smtp-relay.brevo.com"
+      SMTP_PORT: "587"
+      SMTP_USER: "ac716e001@smtp-brevo.com"
+      SMTP_PASS: "${SMTP_PASS}"
       SMTP_FROM: "noreplymagicvs@gmail.com"
       DECK_MIN_CARDS: ${DECK_MIN_CARDS:-60}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       SMTP_HOST: "smtp-relay.brevo.com"
       SMTP_PORT: "587"
       SMTP_USER: "ac716e001@smtp-brevo.com"
-      SMTP_PASS: "${SMTP_PASS}"
+      SMTP_PASS: "xsmtpsib-66c2d82e67c60891069847d8142822801b9a733b003dcdde40e317152f3b0322-0WZBeDbnyDZGdSgj"
       SMTP_FROM: "noreplymagicvs@gmail.com"
       DECK_MIN_CARDS: ${DECK_MIN_CARDS:-60}
     ports:

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -44,6 +44,7 @@ export const routes: Routes = [
       { path: 'users/:id', component: UserProfileComponent },
       { path: 'arena', component: MatchBrowserComponent, canActivate: [authGuard] },
       { path: 'battle/:id', component: BattleboardComponent, canActivate: [authGuard] },
+      { path: 'spectator/:id', loadComponent: () => import('./features/spectator/spectator.component').then(m => m.SpectatorComponent), canActivate: [authGuard] },
       { path: 'reset-password/:token', component: ResetPassword },
       { path: 'logros', component: AchievementsPageComponent }
     ]

--- a/frontend/src/app/core/services/match.service.ts
+++ b/frontend/src/app/core/services/match.service.ts
@@ -61,4 +61,12 @@ export class MatchService {
       map(matches => matches.find(m => m.id === id))
     );
   }
+
+  getActiveFriendsMatches(): Observable<Match[]> {
+    return this.http.get<Match[]>(`${this.apiUrl}/friends/active`, { headers: this.getHeaders() });
+  }
+
+  getSpectatorState(matchId: string, friendId: string): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}/${matchId}/spectate?friendId=${friendId}`, { headers: this.getHeaders() });
+  }
 }

--- a/frontend/src/app/features/spectator/spectator.component.html
+++ b/frontend/src/app/features/spectator/spectator.component.html
@@ -1,0 +1,678 @@
+<div class="absolute top-0 left-1/2 -translate-x-1/2 mt-4 px-6 py-2 bg-black/60 backdrop-blur-md rounded-full border border-orange-500/50 shadow-[0_0_15px_rgba(249,115,22,0.5)] z-50 flex items-center gap-2 animate-pulse"><span class="material-symbols-outlined text-orange-400">visibility</span><span class="text-orange-100 font-bold tracking-widest text-sm uppercase">Modo Espectador</span></div>
+@if (gameState) {
+  <main class="battlefield relative w-full mt-20 h-[calc(100vh-80px)] bg-cover bg-center select-none"
+        style="background-image: url('assets/art/arene-bg.webp'); font-family: 'Inter', sans-serif;">
+    
+    <!-- VICTORY / DEFEAT OVERLAY -->
+    @if (gameState.winnerId) {
+      <div class="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/80 backdrop-blur-2xl animate-fade-in">
+        <div class="relative">
+          <!-- Glow effect -->
+          <div [class]="'absolute inset-0 blur-[100px] opacity-50 ' + (gameState.winnerId === me.id ? 'bg-primary' : 'bg-red-600')"></div>
+          
+          <div class="relative flex flex-col items-center text-center">
+            @if (gameState.winnerId === me.id) {
+              <div class="text-8xl font-black font-headline text-white uppercase tracking-tighter mb-2 animate-victory drop-shadow-2xl">¡Victoria!</div>
+              <div class="text-primary text-xl font-black uppercase tracking-[0.4em] mb-12">Has dominado el campo de batalla</div>
+            } @else if (gameState.winnerId === 'DRAW') {
+                <div class="text-8xl font-black font-headline text-white uppercase tracking-tighter mb-2 drop-shadow-2xl">¡Empate!</div>
+                <div class="text-zinc-400 text-xl font-black uppercase tracking-[0.4em] mb-12">Nadie sobrevive hoy</div>
+            } @else {
+              <div class="text-8xl font-black font-headline text-white uppercase tracking-tighter mb-2 drop-shadow-2xl text-red-600">Derrota</div>
+              <div class="text-red-400/60 text-xl font-black uppercase tracking-[0.4em] mb-12">Has caído en combate</div>
+            }
+
+            <div class="flex gap-4">
+               <button (click)="goToMenu()" class="bg-white hover:bg-zinc-200 text-black px-10 py-4 rounded-2xl font-black uppercase tracking-widest text-sm transition-all hover:scale-105 active:scale-95 shadow-2xl">
+                 Volver al menú
+               </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- RIGHT SIDEBAR: PHASE, TURN & ACTIONS -->
+    <div class="fixed right-0 top-20 bottom-0 w-28 flex flex-col items-center py-8 z-40 bg-zinc-900/40 backdrop-blur-xl border-l border-white/5 shadow-2xl">
+      <!-- Turn Indicator -->
+      <div class="mb-8 flex flex-col items-center gap-1">
+        <div [class]="'px-3 py-1 rounded-full text-[9px] font-black uppercase tracking-[0.2em] transition-all ' + 
+             (gameState.activePlayerId === me.id ? 'bg-primary text-white shadow-lg shadow-primary/20' : 'bg-zinc-800 text-zinc-500')">
+          {{ gameState.activePlayerId === me.id ? 'Tu Turno' : 'Rival' }}
+        </div>
+        <div class="text-[8px] text-zinc-600 font-bold uppercase tracking-widest mt-1">Turno {{ gameState.turnCount }}</div>
+      </div>
+
+      <!-- Phases Vertical -->
+      <div class="flex-1 flex flex-col justify-center gap-6">
+        @for (phase of ['UNTAP', 'UPKEEP', 'DRAW', 'MAIN 1', 'COMBAT', 'MAIN 2', 'END']; track phase) {
+          <div class="flex flex-col items-center gap-2 group cursor-help">
+            <div [class]="'w-1.5 h-1.5 rounded-full transition-all duration-300 ' + 
+                 (gameState.currentPhase === phase ? 'bg-primary shadow-[0_0_15px_rgba(142,68,173,0.8)] scale-150' : 'bg-white/20 group-hover:bg-white/40')"></div>
+            <span [class]="'text-[8px] font-black uppercase tracking-[0.2em] transition-all ' + 
+                  (gameState.currentPhase === phase ? 'text-white' : 'text-zinc-700')">{{ phase }}</span>
+          </div>
+        }
+      </div>
+
+      <!-- Pass Priority Button -->
+      <div class="mt-auto flex flex-col gap-2 pb-8">
+        @if (gameState.activePlayerId === me.id) {
+          <button (click)="engine.forceNextPhase()" 
+                  class="bg-red-500/20 hover:bg-red-500/40 text-red-400 w-20 py-2 rounded-xl text-[7px] font-black uppercase tracking-widest transition-all">
+            Fuerza Bruta
+          </button>
+          <button (click)="engine.resetLives()" 
+                  class="bg-blue-500/20 hover:bg-blue-500/40 text-blue-400 w-20 py-2 rounded-xl text-[7px] font-black uppercase tracking-widest transition-all mt-2">
+            Reset HP
+          </button>
+        }
+        <button (click)="onPassPriority()" 
+                [disabled]="gameState.priorityPlayerId !== me.id || engine.getIsProcessing()"
+                [class.opacity-30]="gameState.priorityPlayerId !== me.id"
+                class="bg-white hover:bg-zinc-200 text-black w-20 h-20 rounded-full flex flex-col items-center justify-center gap-1 shadow-2xl transition-all hover:-translate-y-1 active:translate-y-0 group disabled:cursor-not-allowed">
+          @if (engine.getIsProcessing()) {
+            <span class="material-symbols-outlined text-xl animate-spin text-zinc-400">sync</span>
+          } @else {
+            <span class="material-symbols-outlined text-xl group-hover:rotate-12 transition-transform">
+              {{ gameState.stack.length > 0 ? 'check_circle' : 'fast_forward' }}
+            </span>
+          }
+          <span class="text-[8px] font-black uppercase tracking-tighter">
+            {{ engine.getIsProcessing() ? 'Sinc...' : (gameState.stack.length > 0 ? 'Resolver' : 'Pasar') }}
+          </span>
+        </button>
+      </div>
+    </div>
+
+    <!-- SHUFFLING OVERLAY -->
+    @if (gameState.animationStatus === 'SHUFFLING') {
+      <div class="fixed inset-0 z-[100] flex flex-col items-center justify-center bg-black/60 backdrop-blur-md animate-fade-in">
+        <div class="relative w-32 h-44 mb-6">
+          <div class="absolute inset-0 bg-zinc-800 rounded-xl border-2 border-primary/40 shadow-[0_0_30px_rgba(142,68,173,0.3)] animate-pulse"></div>
+          <div class="absolute inset-0 flex items-center justify-center">
+            <span class="material-symbols-outlined text-4xl text-primary animate-spin">refresh</span>
+          </div>
+        </div>
+        <div class="text-2xl font-black font-headline text-white tracking-[0.2em] uppercase animate-bounce-subtle">Barajando...</div>
+        <div class="text-zinc-400 text-xs mt-2 font-label uppercase tracking-widest">Preparando hechizos</div>
+      </div>
+    }
+
+    <!-- MULLIGAN DECISION OVERLAY -->
+    @if (gameState.currentPhase === 'MULLIGAN_DECIDING' && me && !me.isReady) {
+      <div class="fixed inset-x-0 top-24 z-[100] flex flex-col items-center animate-fade-in pointer-events-none">
+        <div class="bg-zinc-900/95 border border-white/10 p-6 rounded-[2rem] shadow-[0_20px_40px_rgba(0,0,0,0.6)] flex items-center gap-8 max-w-2xl pointer-events-auto backdrop-blur-md">
+          <div class="flex flex-col">
+            <h2 class="text-xl font-black font-headline text-white uppercase tracking-tight leading-none">¿Te quedas esta mano?</h2>
+            <p class="text-zinc-500 text-[10px] font-label uppercase tracking-widest mt-1">Mulligan actual: {{ me.mulliganCount }}</p>
+          </div>
+          
+          <div class="flex gap-3">
+            <button (click)="onMulligan()" class="bg-zinc-800 hover:bg-zinc-700 text-white px-6 py-3 rounded-xl font-black uppercase text-xs tracking-widest transition-all active:scale-95">Mulligan</button>
+            <button (click)="onKeep()" class="arcane-gradient text-white px-8 py-3 rounded-xl font-black uppercase text-xs tracking-widest transition-all active:scale-95 shadow-lg">Mantener</button>
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- MULLIGAN DROP CARDS INSTRUCTION -->
+    @if (gameState.currentPhase === 'MULLIGAN' && me && !me.isReady) {
+      <div class="fixed inset-x-0 top-24 z-[100] flex flex-col items-center animate-fade-in pointer-events-none">
+        <div class="bg-primary/20 border border-primary/40 px-10 py-5 rounded-[2rem] backdrop-blur-lg animate-bounce-subtle flex flex-col items-center shadow-xl">
+          <div class="text-[10px] font-black text-primary uppercase tracking-[0.3em] mb-1">Mulligan confirmado</div>
+          <div class="text-xl font-black text-white font-headline uppercase leading-none">
+            Suelta {{ Math.max(0, me.mulliganCount - (7 - me.hand.length)) }} cartas al fondo
+          </div>
+          <div class="text-[10px] text-zinc-400 mt-2 uppercase tracking-widest">Haz clic en las cartas de tu mano</div>
+        </div>
+      </div>
+    }
+
+    <!-- WAITING FOR OPPONENT OVERLAY -->
+    @if ((gameState.currentPhase === 'MULLIGAN' || gameState.currentPhase === 'MULLIGAN_DECIDING') && me && opponent && me.isReady && !opponent.isReady) {
+      <div class="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/10">
+        <div class="bg-zinc-900/90 p-8 rounded-3xl border border-white/10 shadow-2xl flex flex-col items-center">
+          <div class="w-12 h-12 border-4 border-primary border-t-transparent rounded-full animate-spin mb-4"></div>
+          <div class="text-xl font-black text-white uppercase tracking-widest">Esperando al oponente...</div>
+          <div class="text-zinc-500 text-xs mt-2 uppercase tracking-widest">El duelo comenzará pronto</div>
+        </div>
+      </div>
+    }    
+    
+    @if (me && opponent) {
+      <div class="absolute top-4 right-32 z-30 pointer-events-none flex flex-col items-end gap-3">
+        <!-- OPPONENT AVATAR CARD -->
+        <div class="bg-zinc-900/80 rounded-2xl px-5 py-3 border flex items-center gap-5 backdrop-blur-md shadow-2xl pointer-events-auto min-w-[220px] transition-all"
+             [class.border-white/5]="!gameState.pendingTarget || (gameState.pendingTarget.validTargets !== 'PLAYER' && gameState.pendingTarget.validTargets !== 'ANY')"
+             [class.border-primary]="gameState.pendingTarget && (gameState.pendingTarget.validTargets === 'PLAYER' || gameState.pendingTarget.validTargets === 'ANY')"
+             [class.targetable-glow]="gameState.pendingTarget && (gameState.pendingTarget.validTargets === 'PLAYER' || gameState.pendingTarget.validTargets === 'ANY')"
+             (click)="engine.targetPlayer(opponent.id)">
+          <app-avatar [username]="opponent.username" [avatarUrl]="opponent.avatarUrl" size="md" class="border-2 border-white/10 rounded-full shadow-lg"></app-avatar>
+          <div class="flex flex-col">
+            <div class="flex items-center gap-3">
+              <span class="text-3xl font-black text-white leading-none tracking-tighter">{{ opponent.hp }}</span>
+              <span class="text-[10px] text-zinc-500 uppercase font-black tracking-[0.2em]">Rival</span>
+            </div>
+            <div class="text-[11px] text-white/40 font-bold uppercase tracking-widest truncate max-w-[120px] mt-1">{{ opponent.username }}</div>
+          </div>
+        </div>
+
+        <!-- OPPONENT DECK & GRAVEYARD -->
+        <div class="flex gap-4 pointer-events-auto mr-4">
+          <div class="flex flex-col items-center group">
+            <div class="w-12 h-12 bg-zinc-900/90 rounded-2xl border border-white/10 flex flex-col items-center justify-center shadow-xl transition-all group-hover:border-primary/40 group-hover:-translate-y-1">
+              <span class="text-[9px] text-zinc-500 uppercase font-black">C</span>
+              <span class="text-xs text-white font-black leading-none mt-1">{{ opponent.graveyard?.length || 0 }}</span>
+            </div>
+          </div>
+          <div class="flex flex-col items-center group">
+            <div class="w-12 h-12 bg-zinc-900/90 rounded-2xl border border-white/10 flex flex-col items-center justify-center shadow-xl transition-all group-hover:border-primary/40 group-hover:-translate-y-1">
+              <span class="text-[9px] text-zinc-500 uppercase font-black">M</span>
+              <span class="text-xs text-white font-black leading-none mt-1">{{ opponent.libraryCount }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- OPPONENT MANA POOL -->
+        <div class="mana-pool-grid grid grid-cols-3 gap-1.5 pointer-events-auto mr-2">
+          @for (mana of [
+            { key: 'white', color: '#fcd34d', icon: 'brightness_low' },
+            { key: 'blue', color: '#3b82f6', icon: 'water_drop' },
+            { key: 'black', color: '#a855f7', icon: 'skull' },
+            { key: 'red', color: '#ef4444', icon: 'local_fire_department' },
+            { key: 'green', color: '#22c55e', icon: 'park' },
+            { key: 'colorless', color: '#94a3b8', icon: 'diamond' }
+          ]; track mana.key) {
+            <div class="mana-icon-wrapper flex flex-col items-center opacity-40 transition-opacity" [class.active]="opponent.manaPool && opponent.manaPool[mana.key] > 0">
+              <span class="mana-count mb-0.5">{{ opponent.manaPool ? opponent.manaPool[mana.key] : 0 }}</span>
+              <div class="mana-circle" 
+                   [style.background-color]="mana.color"
+                   [style.border-color]="mana.color"
+                   style="color: rgba(0,0,0,0.8)">
+                <span class="material-symbols-outlined !text-[12px] font-bold">{{ mana.icon }}</span>
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+
+      <!-- THE STACK VISUALIZATION -->
+      @if (gameState.stack.length > 0) {
+        <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[150] flex flex-col items-center gap-4 pointer-events-none">
+          <div class="text-white/40 text-[10px] font-black uppercase tracking-[0.5em] mb-4 italic">Hechizos en resolución</div>
+          
+          <div class="flex flex-col-reverse gap-4">
+            @for (item of gameState.stack; track item.id; let last = $last) {
+              <div class="stack-item flex items-center gap-4 animate-slide-up pointer-events-auto"
+                   [class.active-resolution]="last">
+                <div class="w-24 h-34 rounded-xl overflow-hidden border-2 border-primary/40 shadow-[0_0_30px_rgba(var(--primary-rgb),0.3)] relative">
+                  <img [src]="item.imageUrl" class="w-full h-full object-cover">
+                  <div class="absolute inset-0 bg-black/40 flex flex-col items-center justify-center p-2 text-center">
+                    <div class="text-[8px] text-white font-black uppercase leading-tight">{{ item.name }}</div>
+                    <div class="text-[6px] text-white/60 font-bold uppercase mt-1">{{ item.type }}</div>
+                  </div>
+                </div>
+                
+                @if (last) {
+                  <div class="flex flex-col gap-2">
+                    <div class="bg-primary px-3 py-1 rounded-full text-[8px] font-black text-black uppercase tracking-widest animate-pulse">
+                      Resolviendo...
+                    </div>
+                    <div class="flex gap-1 justify-center">
+                      <div class="w-2 h-2 rounded-full" [class.bg-green-500]="gameState.passedCount >= 1" [class.bg-zinc-700]="gameState.passedCount < 1"></div>
+                      <div class="w-2 h-2 rounded-full" [class.bg-green-500]="gameState.passedCount >= 2" [class.bg-zinc-700]="gameState.passedCount < 2"></div>
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- CENTER AREA: BATTLEFIELD -->
+      <div class="absolute inset-x-24 top-[45%] -translate-y-1/2 flex flex-col gap-8 z-20 pr-32">
+        
+        <!-- OPPONENT FIELD -->
+        <div class="opponent-area flex flex-col gap-2 relative">
+          <div class="absolute -inset-10 bg-red-500/5 blur-3xl rounded-full pointer-events-none"></div>
+          
+          <!-- Opponent Permanents -->
+          <div class="permanents-row">
+            @for (card of getNonLands(opponent.field); track card.id) {
+              <div class="card-zoom-container" (mouseenter)="onHoverCard(card)" (mouseleave)="onClearHover()" (click)="onTapCard(card.id)">
+                <div class="card-battle-mode" 
+                     [class.tapped]="card.isTapped"
+                     [class.attacking]="card.isAttacking"
+                     [class.blocking]="card.isBlocking"
+                     [class.animate-hit]="isHitting(card.id)"
+                     [class.ring-4]="card.isAttacking && !card.blockingTargetId"
+                     [class.ring-primary]="card.isAttacking"
+                     [style.box-shadow]="card.blockingTargetId ? '0 0 30px 5px rgba(59, 130, 246, 0.8)' : (card.isAttacking ? '0 0 20px rgba(var(--primary-rgb), 0.5)' : 'none')"
+                     [style.border-radius]="'12px'"
+                     [class.targetable-glow]="gameState.pendingTarget && (gameState.pendingTarget.validTargets === 'CREATURE' || gameState.pendingTarget.validTargets === 'ANY')">
+                  
+                  @if (isHitting(card.id)) {
+                    <div class="damage-number">-{{ getRecentDamage(card.id) }}</div>
+                  }
+
+                  <div class="card-art-crop">
+                    <img [src]="card.imageUrl" [alt]="card.name">
+                    @if (card.isTapped && !card.isAttacking) { <div class="absolute inset-0 bg-black/40 flex items-center justify-center"><span class="material-symbols-outlined text-white text-lg animate-spin-slow">rotate_right</span></div> }
+                  </div>
+                  @if (card.isAttacking) {
+                    <div class="combat-badge attacker">
+                      <span class="material-symbols-outlined text-[10px]">swords</span>
+                    </div>
+                  }
+                  @if (card.blockingTargetId) {
+                    <div class="combat-badge blocker">
+                      <span class="material-symbols-outlined text-[10px]">shield</span>
+                    </div>
+                  }
+                  @if (card.power !== undefined && card.toughness !== undefined) {
+                    <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 bg-black border border-white/20 text-[10px] font-black text-white px-1.5 py-0 rounded shadow-lg z-10 flex gap-0.5 pointer-events-none">
+                      <span>{{ engine.getModifiedPower(card, opponent) }}</span>
+                      <span>/</span>
+                      <span [class.text-red-400]="card.damageTaken > 0">{{ getRemainingToughness(card, opponent) }}</span>
+                    </div>
+                  }
+                </div>
+              </div>
+            }
+
+            <!-- Opponent Dying Cards -->
+            @for (card of dyingCards; track card.id) {
+              @if (card.ownerId === opponent.id) {
+                <div class="card-battle-mode animate-death grayscale opacity-50 relative">
+                  <div class="card-art-crop">
+                    <img [src]="card.imageUrl">
+                  </div>
+                  <div class="absolute inset-0 flex items-center justify-center z-50">
+                    <span class="material-symbols-outlined text-red-600 text-5xl drop-shadow-[0_0_10px_rgba(255,0,0,0.8)] animate-pulse">skull</span>
+                  </div>
+                </div>
+              }
+            }
+          </div>
+
+          <!-- Opponent Lands -->
+          <div class="lands-row">
+            @for (card of getLands(opponent.field); track card.id) {
+              <div class="card-zoom-container" (mouseenter)="onHoverCard(card)" (mouseleave)="onClearHover()">
+                <div class="card-battle-mode" 
+                     [class.tapped]="card.isTapped"
+                     [class.attacking]="card.isAttacking"
+                     [class.blocking]="card.isBlocking">
+                  <div class="card-art-crop">
+                    <img [src]="card.imageUrl" [alt]="card.name">
+                    @if (card.isTapped && !card.isAttacking) { <div class="absolute inset-0 bg-black/40 flex items-center justify-center"><span class="material-symbols-outlined text-white text-lg animate-spin-slow">rotate_right</span></div> }
+                  </div>
+                  @if (card.isAttacking) {
+                    <div class="combat-badge attacker">
+                      <span class="material-symbols-outlined text-[10px]">swords</span>
+                    </div>
+                  }
+                </div>
+              </div>
+            }
+            @if (getLands(opponent.field).length === 0) { <div class="opacity-10 text-[8px] uppercase font-black tracking-[0.5em] self-center">Tierras</div> }
+          </div>
+        </div>
+
+
+        <div class="h-px bg-white/5 w-full"></div>
+
+        <!-- PLAYER FIELD -->
+        <div class="flex flex-col gap-2 relative">
+          <div class="absolute -inset-20 bg-primary/5 blur-[100px] rounded-full pointer-events-none"></div>
+          
+          <!-- Player Permanents -->
+          <div class="permanents-row">
+            @for (card of getNonLands(me.field); track card.id) {
+              <div class="card-zoom-container" 
+                   (mouseenter)="onHoverCard(card)" (mouseleave)="onClearHover()"
+                    (click)="onTapCard(card.id)">
+                <div class="card-battle-mode" 
+                     [class.tapped]="card.isTapped"
+                     [class.attacking]="card.isAttacking"
+                     [class.blocking]="card.isBlocking"
+                     [class.animate-hit]="isHitting(card.id)"
+                     [class.ring-4]="card.isAttacking && !card.blockingTargetId"
+                     [class.ring-primary]="card.isAttacking"
+                     [style.box-shadow]="card.blockingTargetId ? '0 0 30px 5px rgba(59, 130, 246, 0.8)' : (card.isAttacking ? '0 0 20px rgba(var(--primary-rgb), 0.5)' : 'none')"
+                     [style.border-radius]="'12px'"
+                     [class.targetable-glow]="gameState.pendingTarget && (gameState.pendingTarget.validTargets === 'CREATURE' || gameState.pendingTarget.validTargets === 'ANY')">
+                  
+                  @if (isHitting(card.id)) {
+                    <div class="damage-number">-{{ getRecentDamage(card.id) }}</div>
+                  }
+
+                  <div class="absolute -inset-4 bg-primary/20 blur-xl opacity-0 group-hover:opacity-100 transition-opacity rounded-full"></div>
+                  <div class="card-art-crop">
+                    <img [src]="card.imageUrl" [alt]="card.name">
+                    @if (card.isTapped && !card.isAttacking) { <div class="absolute inset-0 bg-black/40 flex items-center justify-center"><span class="material-symbols-outlined text-white text-lg animate-spin-slow">rotate_right</span></div> }
+                  </div>
+                  @if (card.isAttacking) {
+                    <div class="combat-badge attacker">
+                      <span class="material-symbols-outlined text-[10px]">swords</span>
+                    </div>
+                  }
+                  @if (card.blockingTargetId) {
+                    <div class="combat-badge blocker">
+                      <span class="material-symbols-outlined text-[10px]">shield</span>
+                    </div>
+                  }
+                  @if (card.power !== undefined && card.toughness !== undefined) {
+                    <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 bg-black border border-white/20 text-[10px] font-black text-white px-1.5 py-0 rounded shadow-lg z-10 flex gap-0.5 pointer-events-none">
+                      <span>{{ engine.getModifiedPower(card, me) }}</span>
+                      <span>/</span>
+                      <span [class.text-red-400]="card.damageTaken > 0">{{ getRemainingToughness(card, me) }}</span>
+                    </div>
+                  }
+                </div>
+              </div>
+            }
+
+            <!-- Player Dying Cards -->
+            @for (card of dyingCards; track card.id) {
+              @if (card.ownerId === me.id) {
+                <div class="card-battle-mode animate-death grayscale opacity-50 relative">
+                  <div class="card-art-crop">
+                    <img [src]="card.imageUrl">
+                  </div>
+                  <div class="absolute inset-0 flex items-center justify-center z-50">
+                    <span class="material-symbols-outlined text-red-600 text-5xl drop-shadow-[0_0_10px_rgba(255,0,0,0.8)] animate-pulse">skull</span>
+                  </div>
+                </div>
+              }
+            }
+          </div>
+
+          <!-- Player Lands -->
+          <div class="lands-row">
+            @for (card of getLands(me.field); track card.id) {
+              <div class="card-zoom-container relative" 
+                   (mouseenter)="onHoverCard(card)" (mouseleave)="onClearHover()">
+                <div class="card-battle-mode cursor-pointer" 
+                     [class.tapped]="card.isTapped"
+                     [class.attacking]="card.isAttacking"
+                     [class.blocking]="card.isBlocking"
+                     (click)="onTapCard(card.id)">
+                  <div class="card-art-crop">
+                    <img [src]="card.imageUrl" [alt]="card.name">
+                    @if (card.isTapped && !card.isAttacking) { 
+                      <div class="absolute inset-0 bg-black/40 flex items-center justify-center">
+                        <span class="material-symbols-outlined text-white text-lg animate-spin-slow">rotate_right</span>
+                      </div> 
+                    }
+                  </div>
+                </div>
+              </div>
+            }
+            @if (getLands(me.field).length === 0) { <div class="opacity-10 text-[8px] uppercase font-black tracking-[0.5em] self-center">Tierras</div> }
+          </div>
+        </div>
+      </div>
+
+      <!-- PREMIUM PAYMENT OVERLAY -->
+      @if (gameState.pendingPayment; as pay) {
+        @if (gameState.activePlayerId === me.id) {
+          <div class="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/60 backdrop-blur-md animate-fade-in">
+            <div class="text-white font-black text-2xl uppercase tracking-[0.3em] mb-4 animate-slide-up">Pagar Maná Genérico</div>
+            <div class="text-white/60 text-sm font-bold uppercase tracking-widest mb-12 animate-slide-up">Restante: {{ pay.remainingGeneric }}</div>
+            
+            <div class="flex gap-4 max-w-2xl flex-wrap justify-center animate-scale-in">
+              @for (poolKey of ['white', 'blue', 'black', 'red', 'green', 'colorless']; track poolKey) {
+                @if (me.manaPool[poolKey] > 0) {
+                  <button (click)="engine.payGenericMana(poolKey)"
+                          class="mana-choice-btn w-20 h-20 rounded-full flex flex-col items-center justify-center gap-1 transition-all hover:scale-110 active:scale-95 shadow-[0_0_30px_rgba(0,0,0,0.5)] border-2 border-white/20 hover:border-white/50 relative"
+                          [style.background-color]="getColorCode(poolKey === 'colorless' ? 'C' : poolKey.charAt(0))">
+                    <span class="absolute -top-2 -right-2 w-6 h-6 bg-black text-white rounded-full text-xs font-black flex items-center justify-center border border-white/20">
+                      {{ me.manaPool[poolKey] }}
+                    </span>
+                    <span class="material-symbols-outlined text-black text-3xl font-bold">{{ getColorIcon(poolKey === 'colorless' ? 'C' : poolKey.charAt(0)) }}</span>
+                  </button>
+                }
+              }
+            </div>
+            
+            <button (click)="engine.cancelPayment()"
+                    class="mt-12 px-6 py-2 rounded-full border border-white/20 text-white/60 text-xs font-bold uppercase tracking-widest hover:bg-white/10 hover:text-white transition-all">
+              Cancelar
+            </button>
+          </div>
+        }
+      }
+
+      <!-- MULTI-BLOCKING ORDER OVERLAY -->
+      @if (gameState.pendingBlockerOrders && gameState.pendingBlockerOrders.length > 0) {
+        <div class="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/80 backdrop-blur-md animate-fade-in">
+            <div class="text-white font-black text-2xl uppercase tracking-[0.3em] mb-2 animate-slide-up text-center">Orden de Daño</div>
+            <div class="text-white/60 text-sm font-bold uppercase tracking-widest mb-12 animate-slide-up text-center">Haz clic en los bloqueadores en el orden que quieres destruirlos</div>
+            
+            <div class="flex gap-4 max-w-4xl flex-wrap justify-center animate-scale-in">
+              @for (blockerId of gameState.pendingBlockerOrders[0].blockerIds; track blockerId) {
+                <div class="card-zoom-container relative group" 
+                     [class.cursor-pointer]="gameState.activePlayerId === (me?.id)"
+                     (click)="gameState.activePlayerId === (me?.id) && toggleBlockerOrderSelection(blockerId)">
+                  <div class="w-[140px] h-[195px] rounded-xl overflow-hidden border-2 transition-all shadow-2xl relative"
+                       [class.border-white]="!isBlockerSelected(blockerId)"
+                       [class.border-primary]="isBlockerSelected(blockerId)"
+                       [class.scale-95]="isBlockerSelected(blockerId)">
+                    
+                    <img [src]="getCardById(blockerId)?.imageUrl" class="w-full h-full object-cover">
+                    
+                    @if (isBlockerSelected(blockerId)) {
+                      <div class="absolute inset-0 bg-primary/40 flex items-center justify-center">
+                        <div class="w-12 h-12 bg-primary text-black rounded-full text-2xl font-black flex items-center justify-center border-4 border-black">
+                          {{ getBlockerSelectionIndex(blockerId) }}
+                        </div>
+                      </div>
+                    } @else {
+                      <div class="absolute inset-0 bg-black/40 group-hover:bg-transparent transition-colors"></div>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+            
+            <button (click)="submitBlockerOrder()"
+                    [disabled]="!isBlockerOrderComplete() || gameState.activePlayerId !== (me?.id)"
+                    class="mt-12 px-12 py-4 rounded-full bg-primary text-black font-black uppercase tracking-widest hover:scale-105 active:scale-95 disabled:opacity-50 disabled:scale-100 disabled:pointer-events-none transition-all shadow-[0_0_30px_rgba(var(--primary-rgb),0.3)]">
+              {{ gameState.activePlayerId === (me?.id) ? 'Confirmar Orden' : 'Esperando al Atacante...' }}
+            </button>
+          </div>
+      }
+
+      <!-- PREMIUM MANA SELECTION OVERLAY -->
+      @if (gameState.pendingManaChoice; as choice) {
+        @if (choice.playerId === me.id) {
+          <div class="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/60 backdrop-blur-md animate-fade-in">
+            <div class="text-white font-black text-2xl uppercase tracking-[0.3em] mb-12 animate-slide-up">Elige un color de maná</div>
+            
+            <div class="flex gap-8 animate-scale-in">
+              @for (color of choice.options; track color) {
+                <div class="flex flex-col items-center gap-4 group">
+                  <button (click)="engine.resolveManaChoice(color)"
+                          class="mana-choice-btn w-24 h-24 rounded-full flex items-center justify-center transition-all hover:scale-110 active:scale-95 shadow-[0_0_30px_rgba(0,0,0,0.5)] border-2 border-white/20 hover:border-white/50"
+                          [style.background-color]="getColorCode(color)">
+                    <span class="material-symbols-outlined text-black text-5xl font-bold">{{ getColorIcon(color) }}</span>
+                  </button>
+                  <span class="text-white/60 font-bold uppercase tracking-widest text-[10px] opacity-0 group-hover:opacity-100 transition-opacity">
+                    {{ getColorName(color) }}
+                  </span>
+                </div>
+              }
+            </div>
+          </div>
+        }
+      }
+
+      <!-- PREMIUM PAYMENT OVERLAY -->
+      @if (gameState.pendingPayment; as payment) {
+        <div class="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/80 backdrop-blur-xl animate-fade-in">
+          <div class="text-primary font-black text-xs uppercase tracking-[0.4em] mb-2 animate-slide-up">Pago de Hechizo</div>
+          <div class="text-white font-black text-3xl uppercase tracking-[0.2em] mb-12 animate-scale-in">
+            Paga {{ payment.remainingGeneric }} maná genérico
+          </div>
+          
+          <div class="flex gap-6 mb-16 animate-scale-in">
+            @for (mana of [
+              { key: 'white', color: '#fcd34d', icon: 'brightness_low' },
+              { key: 'blue', color: '#3b82f6', icon: 'water_drop' },
+              { key: 'black', color: '#a855f7', icon: 'skull' },
+              { key: 'red', color: '#ef4444', icon: 'local_fire_department' },
+              { key: 'green', color: '#22c55e', icon: 'park' },
+              { key: 'colorless', color: '#94a3b8', icon: 'diamond' }
+            ]; track mana.key) {
+              @if (me.manaPool && me.manaPool[mana.key] > 0) {
+                <div class="flex flex-col items-center gap-3 group">
+                  <button (click)="engine.payGenericMana($any(mana.key))"
+                          class="w-20 h-20 rounded-full flex items-center justify-center transition-all hover:scale-110 active:scale-95 shadow-2xl border-2 border-white/20 hover:border-white/50"
+                          [style.background-color]="mana.color">
+                    <span class="material-symbols-outlined text-black text-4xl font-bold">{{ mana.icon }}</span>
+                  </button>
+                  <span class="text-white font-black text-xl">{{ me.manaPool[mana.key] }}</span>
+                </div>
+              }
+            }
+          </div>
+
+          <div class="flex gap-4 animate-slide-up">
+            <button (click)="engine.cancelPayment()" 
+                    class="px-8 py-4 rounded-xl border border-white/10 text-white/40 font-black uppercase tracking-widest hover:bg-white/5 transition-all">
+              Cancelar
+            </button>
+            <button (click)="engine.autoPayGeneric()" 
+                    class="arcane-gradient px-12 py-4 rounded-xl text-white font-black uppercase tracking-widest shadow-lg hover:brightness-110 transition-all">
+              Pago Automático
+            </button>
+          </div>
+        </div>
+      }
+
+      <!-- BOTTOM SECTION: PLAYER -->
+      <div class="absolute bottom-0 inset-x-0 h-64 z-30 pointer-events-none">
+        <!-- PLAYER STATS -->
+        <!-- BOTTOM RIGHT: PLAYER STATS -->
+        <div class="absolute bottom-4 right-32 pointer-events-none flex flex-col items-end gap-3">
+          <!-- MANA POOL -->
+          <div class="mana-pool-grid grid grid-cols-3 gap-1.5 pointer-events-auto mr-2">
+            @for (mana of [
+              { key: 'white', color: '#fcd34d', icon: 'brightness_low' },
+              { key: 'blue', color: '#3b82f6', icon: 'water_drop' },
+              { key: 'black', color: '#a855f7', icon: 'skull' },
+              { key: 'red', color: '#ef4444', icon: 'local_fire_department' },
+              { key: 'green', color: '#22c55e', icon: 'park' },
+              { key: 'colorless', color: '#94a3b8', icon: 'diamond' }
+            ]; track mana.key) {
+              <div class="mana-icon-wrapper flex flex-col items-center opacity-40 transition-opacity" [class.active]="me.manaPool && me.manaPool[mana.key] > 0">
+                <span class="mana-count mb-0.5">{{ me.manaPool ? me.manaPool[mana.key] : 0 }}</span>
+                <div class="mana-circle" 
+                     [style.background-color]="mana.color"
+                     [style.border-color]="mana.color"
+                     style="color: rgba(0,0,0,0.8)">
+                  <span class="material-symbols-outlined !text-[12px] font-bold">{{ mana.icon }}</span>
+                </div>
+              </div>
+            }
+          </div>
+
+          <!-- PLAYER DECK & GRAVEYARD -->
+          <div class="flex gap-4 pointer-events-auto mr-4">
+            <div class="flex flex-col items-center group">
+              <div class="w-12 h-12 bg-zinc-900/90 rounded-2xl border border-white/10 flex flex-col items-center justify-center shadow-xl transition-all group-hover:border-primary/40 group-hover:-translate-y-1">
+                <span class="text-[9px] text-zinc-500 uppercase font-black">C</span>
+                <span class="text-xs text-white font-black leading-none mt-1">{{ me.graveyard?.length || 0 }}</span>
+              </div>
+            </div>
+            <div class="flex flex-col items-center group">
+              <div class="w-12 h-12 bg-zinc-900/90 rounded-2xl border border-white/10 flex flex-col items-center justify-center shadow-xl transition-all group-hover:border-primary/40 group-hover:-translate-y-1">
+                <span class="text-[9px] text-zinc-500 uppercase font-black">M</span>
+                <span class="text-xs text-white font-black leading-none mt-1">{{ me.libraryCount }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- PLAYER AVATAR CARD -->
+          <div class="bg-zinc-900/80 rounded-2xl px-5 py-3 border flex items-center gap-5 backdrop-blur-md shadow-2xl pointer-events-auto min-w-[220px] transition-all"
+               [class.border-white/5]="!gameState.pendingTarget || (gameState.pendingTarget.validTargets !== 'PLAYER' && gameState.pendingTarget.validTargets !== 'ANY')"
+               [class.border-primary]="gameState.pendingTarget && (gameState.pendingTarget.validTargets === 'PLAYER' || gameState.pendingTarget.validTargets === 'ANY')"
+               [class.targetable-glow]="gameState.pendingTarget && (gameState.pendingTarget.validTargets === 'PLAYER' || gameState.pendingTarget.validTargets === 'ANY')"
+               (click)="engine.targetPlayer(me.id)">
+            <app-avatar [username]="me.username" [avatarUrl]="me.avatarUrl" size="md" class="border-2 border-primary shadow-[0_0_20px_rgba(142,68,173,0.4)] rounded-full"></app-avatar>
+            <div class="flex flex-col">
+              <div class="flex items-center gap-3">
+                <span class="text-3xl font-black text-white leading-none tracking-tighter">{{ me.hp }}</span>
+                <span class="text-[10px] text-primary uppercase font-black tracking-[0.2em]">Tú</span>
+              </div>
+              <div class="text-[11px] text-white/40 font-bold uppercase tracking-widest truncate max-w-[120px] mt-1">{{ me.username }}</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- HAND FAN -->
+        <div class="absolute bottom-0 left-1/2 -translate-x-1/2 w-[600px] h-48 flex items-end justify-center pointer-events-none">
+          @for (card of me.hand; track card.id; let i = $index) {
+            <div class="hand-card-wrapper card-zoom-container hand-card-zoom cursor-pointer pointer-events-auto"
+                 (mouseenter)="onHoverCard(card)" (mouseleave)="onClearHover()"
+                 [style.--rot]="((i - (me.hand.length-1)/2) * (me.hand.length > 7 ? 5 : 7)) + 'deg'"
+                 [style.--tx]="((i - (me.hand.length-1)/2) * (me.hand.length > 7 ? 25 : 40)) + 'px'"
+                 [style.--ty]="(Math.abs(i - (me.hand.length-1)/2) * 8) + 'px'">
+              
+              <div class="relative group" (click)="onPlayCard(card.id)">
+                <div class="absolute -inset-8 bg-primary/20 blur-3xl opacity-0 group-hover:opacity-100 transition-all rounded-full pointer-events-none"></div>
+                <img [src]="card.imageUrl" 
+                     class="relative z-10 w-28 aspect-[2.5/3.5] object-contain rounded-lg shadow-2xl border border-white/10 group-hover:border-primary/50 transition-all" [alt]="card.name">
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+
+      <button (click)="onConcede()" class="absolute bottom-8 left-8 text-white/30 hover:text-red-500 font-black uppercase text-[10px] tracking-[0.4em] transition-colors pointer-events-auto">
+        Salir del Espectador Batalla
+      </button>
+
+      <!-- MAGNIFIED PREVIEW OVERLAY -->
+      @if (hoveredCard) {
+        <div class="magnified-preview-overlay">
+          <div class="preview-card-wrapper">
+            <img [src]="hoveredCard.imageUrl" [alt]="hoveredCard.name">
+          </div>
+        </div>
+      }
+
+    }
+
+  </main>
+}
+
+<!-- Victory Modal -->
+@if (showVictoryModal) {
+  <div class="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm px-4">
+    <div class="max-w-md w-full bg-zinc-900 rounded-2xl border border-white/10 shadow-2xl p-8 text-center animate-fade-in">
+        <div class="text-primary font-black font-headline text-5xl tracking-tighter mb-2 italic">VICTORIA</div>
+        <div class="text-zinc-400 font-label tracking-widest uppercase text-xs mb-8">Duelo Finalizado</div>
+        
+        <div class="bg-black/40 rounded-xl p-6 mb-8 flex justify-between items-center border border-white/5">
+            <div class="text-left">
+                <div class="text-zinc-500 text-[10px] uppercase font-bold tracking-widest">Puntos ganados</div>
+                <div class="text-2xl font-black font-headline text-white">+24</div>
+            </div>
+            <div class="text-right">
+                <div class="text-zinc-500 text-[10px] uppercase font-bold tracking-widest">Rango</div>
+                <div class="text-xl font-bold font-headline text-white text-primary">Diamante</div>
+            </div>
+        </div>
+
+        <button (click)="showVictoryModal = false" class="w-full arcane-gradient text-white py-4 rounded-xl font-black uppercase tracking-widest hover:brightness-110 active:scale-[0.98] transition-all">
+            Volver al Menú
+        </button>
+    </div>
+  </div>
+}
+
+

--- a/frontend/src/app/features/spectator/spectator.component.scss
+++ b/frontend/src/app/features/spectator/spectator.component.scss
@@ -1,0 +1,434 @@
+.battlefield {
+  overflow: hidden;
+}
+
+// Cards on the table (battlefield)
+.card-battle-mode {
+  width: 110px;
+  height: 80px;
+  border-radius: 6px;
+  overflow: visible; 
+  position: relative;
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  box-shadow: 0 4px 15px rgba(0,0,0,0.6);
+  border: 1px solid rgba(255,255,255,0.1);
+  cursor: pointer;
+
+  .card-art-crop {
+    width: 100%;
+    height: 100%;
+    border-radius: 6px;
+    overflow: hidden;
+    position: relative;
+    background: #111;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: top center; // Fixed at the top to show name/mana
+      transition: transform 0.3s;
+    }
+  }
+
+  &.tapped {
+    transform: rotate(90deg) translateY(-5px);
+  }
+
+  &.attacking {
+    border: 2px solid #ef4444;
+    box-shadow: 0 0 20px rgba(239, 68, 68, 0.5);
+    z-index: 50;
+
+    &.tapped {
+      transform: rotate(90deg) scale(1.1);
+    }
+    &:not(.tapped) {
+      transform: translateY(-15px) scale(1.1);
+    }
+  }
+
+  &.blocking {
+    border: 2px solid #3b82f6;
+    box-shadow: 0 0 20px rgba(59, 130, 246, 0.5);
+    transform: translateY(10px) scale(1.05);
+  }
+
+  .combat-badge {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.7);
+    border: 2px solid white;
+    z-index: 60;
+    animation: combat-badge-pulse 2s infinite ease-in-out;
+
+    .material-symbols-outlined {
+      font-size: 18px !important;
+    }
+
+    &.attacker { background: linear-gradient(135deg, #ef4444, #991b1b); }
+    &.blocker { background: linear-gradient(135deg, #3b82f6, #1e40af); }
+  }
+}
+
+@keyframes combat-badge-pulse {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); box-shadow: 0 4px 15px rgba(0,0,0,0.7); }
+  50% { transform: translate(-50%, -50%) scale(1.15); box-shadow: 0 8px 25px rgba(0,0,0,0.8); }
+}
+
+// Hover Indicator (Universal)
+.card-zoom-container {
+  position: relative;
+  transition: transform 0.2s ease-out;
+  
+  &:hover {
+    z-index: 100;
+  }
+}
+
+// Opponent mirroring
+.opponent-area {
+  transform: rotate(180deg);
+}
+
+// Hand Fan Logic
+.hand-card-wrapper {
+  position: absolute;
+  bottom: 0;
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  transform-origin: bottom center;
+  
+  --rot: 0deg;
+  --tx: 0px;
+  --ty: 0px;
+  transform: rotate(var(--rot)) translateX(var(--tx)) translateY(var(--ty));
+
+  &:hover {
+    z-index: 100;
+    transform: rotate(var(--rot)) translateX(var(--tx)) translateY(calc(var(--ty) - 40px)) scale(1.05);
+  }
+}
+
+// MAGNIFIED PREVIEW OVERLAY
+.magnified-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background: rgba(0,0,0,0.2);
+  backdrop-filter: blur(2px);
+  animation: fade-in 0.1s ease-out;
+
+  .preview-card-wrapper {
+    width: 400px;
+    filter: drop-shadow(0 20px 50px rgba(0,0,0,0.8));
+    animation: zoom-in 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    
+    img {
+      width: 100%;
+      border-radius: 20px;
+      border: 2px solid rgba(255,255,255,0.2);
+    }
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes zoom-in {
+  from { transform: scale(0.8); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+// Layout adjustments - Stacking logic (Overlapping)
+.lands-row, .permanents-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
+  max-width: calc(100vw - 320px);
+  padding: 10px;
+  transition: all 0.3s ease;
+
+  .card-zoom-container {
+    margin-right: -40px; // Overlap cards
+    transition: margin 0.2s ease;
+    
+    &:last-child {
+      margin-right: 0;
+    }
+
+    &:hover {
+      margin-right: 0; // Expand on hover for better visibility
+      z-index: 100;
+    }
+  }
+}
+
+.lands-row {
+  background: rgba(255,255,255,0.02);
+  border-radius: 12px;
+  margin: 5px 0;
+}
+
+.arcane-gradient {
+  background: linear-gradient(135deg, #8e44ad 0%, #3498db 100%);
+}
+
+.glass-panel {
+  background: rgba(20, 20, 20, 0.7);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.material-symbols-outlined {
+  vertical-align: middle;
+}
+
+.animate-spin-slow {
+  animation: spin 8s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.targetable-glow {
+  cursor: crosshair !important;
+  animation: target-pulse 1.5s infinite;
+  border: 2px solid #00f2ff !important;
+  box-shadow: 0 0 15px rgba(0, 242, 255, 0.6) !important;
+  z-index: 100 !important;
+
+  &:hover {
+    transform: scale(1.05) !important;
+    box-shadow: 0 0 25px rgba(0, 242, 255, 0.8) !important;
+  }
+}
+
+@keyframes target-pulse {
+  0% { box-shadow: 0 0 5px rgba(0, 242, 255, 0.4); }
+  50% { box-shadow: 0 0 20px rgba(0, 242, 255, 0.8); }
+  100% { box-shadow: 0 0 5px rgba(0, 242, 255, 0.4); }
+}
+
+.mana-pool-grid {
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+
+  .mana-icon-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    width: 28px;
+
+    &.active {
+      opacity: 1;
+      .mana-count { color: white; }
+      .mana-circle { 
+        filter: grayscale(0) contrast(1.1);
+        transform: scale(1.05);
+      }
+    }
+
+    &:not(.active) {
+      .mana-circle {
+        filter: grayscale(0.8) opacity(0.3);
+      }
+    }
+
+    .mana-count {
+      font-size: 9px;
+      font-weight: 900;
+      color: rgba(255,255,255,0.2);
+      transition: color 0.3s;
+    }
+
+    .mana-circle {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid transparent;
+      transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+      
+      .material-symbols-outlined {
+        filter: drop-shadow(0 1px 1px rgba(255,255,255,0.2));
+      }
+    }
+  }
+}
+
+@keyframes slide-up {
+  from { transform: translateY(10px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+/* Premium Mana Selection UI */
+.mana-choice-btn {
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.5);
+  
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(45deg, transparent, rgba(255, 255, 255, 0.3), transparent);
+    transform: translateX(-100%);
+    transition: transform 0.6s;
+  }
+  
+  &:hover::after {
+    transform: translateX(100%);
+  }
+
+  span {
+    filter: drop-shadow(0 0 10px rgba(0,0,0,0.5));
+  }
+}
+
+.animate-scale-in {
+  animation: scaleIn 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+}
+
+@keyframes scaleIn {
+  from { opacity: 0; transform: scale(0.8); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.animate-slide-up {
+  animation: slideUp 0.5s ease-out forwards;
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.3s ease-out forwards;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.animate-victory {
+  animation: victory-bounce 1s cubic-bezier(0.175, 0.885, 0.32, 1.275) infinite alternate;
+}
+
+@keyframes victory-bounce {
+  from { transform: scale(1); filter: drop-shadow(0 0 20px rgba(255,255,255,0.4)); }
+  to { transform: scale(1.1); filter: drop-shadow(0 0 40px rgba(142,68,173,0.8)); }
+}
+
+.animate-shake {
+  animation: shake 0.5s ease-in-out infinite;
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  75% { transform: translateX(5px); }
+}
+
+/* Combat Hit Animation (Red Flash + Shake) */
+.animate-hit {
+  animation: hit-animation 0.4s ease-out forwards;
+}
+
+@keyframes hit-animation {
+  0% { transform: scale(1); filter: brightness(1) drop-shadow(0 0 0 transparent); }
+  20% { transform: scale(1.1) rotate(2deg); filter: brightness(1.5) sepia(1) hue-rotate(-50deg) drop-shadow(0 0 20px #ff0000); }
+  40% { transform: scale(0.9) rotate(-2deg); }
+  60% { transform: scale(1.05) rotate(1deg); }
+  100% { transform: scale(1) rotate(0); filter: brightness(1); }
+}
+
+/* Death Animation (Fade out + Move up) */
+.animate-death {
+  animation: death-animation 0.8s ease-in forwards;
+  pointer-events: none;
+  z-index: 1000 !important;
+}
+
+@keyframes death-animation {
+  0% { transform: translateY(0) scale(1); opacity: 1; filter: grayscale(0); }
+  30% { transform: translateY(-10px) scale(1.1); opacity: 1; filter: grayscale(0.5) contrast(1.5); }
+  100% { transform: translateY(-60px) scale(0.8); opacity: 0; filter: grayscale(1) blur(5px); }
+}
+
+/* Damage Number Floating Animation */
+.damage-number {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #ff3e3e;
+  font-size: 24px;
+  font-weight: 900;
+  text-shadow: 0 0 10px black, 0 0 5px black;
+  z-index: 1001;
+  pointer-events: none;
+  animation: float-up-damage 0.8s ease-out forwards;
+}
+
+@keyframes float-up-damage {
+  0% { transform: translate(-50%, -50%) scale(0.5); opacity: 0; }
+  20% { transform: translate(-50%, -80%) scale(1.5); opacity: 1; }
+  100% { transform: translate(-50%, -150%) scale(1); opacity: 0; }
+}
+
+/* THE STACK STYLES */
+.stack-item {
+  transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  
+  &.active-resolution {
+    .w-24 {
+      border-color: #8e44ad;
+      box-shadow: 0 0 40px rgba(142, 68, 173, 0.6);
+      transform: scale(1.1);
+    }
+  }
+}
+
+.animate-slide-up {
+  animation: stackSlideUp 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+}
+
+@keyframes stackSlideUp {
+  from { 
+    opacity: 0; 
+    transform: translateY(100px) scale(0.5) rotate(15deg);
+    filter: blur(10px);
+  }
+  to { 
+    opacity: 1; 
+    transform: translateY(0) scale(1) rotate(0);
+    filter: blur(0);
+  }
+}

--- a/frontend/src/app/features/spectator/spectator.component.ts
+++ b/frontend/src/app/features/spectator/spectator.component.ts
@@ -1,0 +1,220 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatchService } from '../../core/services/match.service';
+import { AvatarComponent } from '../../shared/components/avatar/avatar.component';
+import { ChangeDetectorRef } from '@angular/core';
+
+@Component({
+  selector: 'app-spectator',
+  standalone: true,
+  imports: [CommonModule, AvatarComponent],
+  templateUrl: './spectator.component.html',
+  styleUrls: ['./spectator.component.scss']
+})
+export class SpectatorComponent implements OnInit, OnDestroy {
+  gameState: any = null;
+  protected readonly Math = Math;
+  matchId: string | null = null;
+  friendId: string | null = null;
+  me: any = null;
+  opponent: any = null;
+  hoveredCard: any = null;
+  
+  private pollingInterval: any = null;
+
+  // Animation states
+  private prevDamageMap = new Map<string, number>();
+  private prevFieldIds = new Set<string>();
+  hittingCards = new Set<string>();
+  dyingCards: any[] = [];
+  lastDamageTaken = new Map<string, number>();
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly matchService: MatchService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.matchId = this.route.snapshot.paramMap.get('id');
+    this.friendId = this.route.snapshot.queryParamMap.get('friendId');
+    
+    if (this.matchId && this.friendId) {
+      this.pollState();
+      this.pollingInterval = setInterval(() => this.pollState(), 3000);
+    } else {
+      this.goToMenu();
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+    }
+  }
+
+  private pollState(): void {
+    this.matchService.getSpectatorState(this.matchId!, this.friendId!).subscribe({
+      next: (state: any) => {
+        this.gameState = state;
+        
+        // Orient the board: "me" is the friend we are spectating
+        if (state.player1?.id === this.friendId) {
+          this.me = state.player1;
+          this.opponent = state.player2;
+        } else {
+          this.me = state.player2;
+          this.opponent = state.player1;
+        }
+
+        this.processStateChanges(state);
+        this.cdr.detectChanges();
+      },
+      error: () => {
+        // If error or game finished, maybe redirect or stop polling
+        clearInterval(this.pollingInterval);
+      }
+    });
+  }
+
+  onHoverCard(card: any): void {
+    this.hoveredCard = card;
+  }
+
+  onClearHover(): void {
+    this.hoveredCard = null;
+  }
+
+  getLands(cards: any[]): any[] {
+    return cards?.filter(c => {
+      const type = (c.type || '').toLowerCase();
+      const name = (c.name || '').toLowerCase();
+      return type.includes('land') || type.includes('tierra') || name.includes('tierra') || 
+             name.includes('isla') || name.includes('pantano') || name.includes('montaña') || 
+             name.includes('bosque') || name.includes('llanura') || name.includes('templo');
+    }) || [];
+  }
+
+  getNonLands(cards: any[]): any[] {
+    const lands = this.getLands(cards);
+    return cards?.filter(c => !lands.find(l => l.id === c.id)) || [];
+  }
+
+  getColorCode(color: string): string {
+    const map: any = { W: '#fcd34d', U: '#3b82f6', B: '#a855f7', R: '#ef4444', G: '#22c55e', C: '#94a3b8' };
+    return map[color.toUpperCase()] || '#94a3b8';
+  }
+
+  getColorIcon(color: string): string {
+    const map: any = { W: 'sunny', U: 'water_drop', B: 'skull', R: 'local_fire_department', G: 'forest', C: 'blur_on' };
+    return map[color.toUpperCase()] || 'help';
+  }
+
+  getColorName(color: string): string {
+    const map: any = { W: 'Blanco', U: 'Azul', B: 'Negro', R: 'Rojo', G: 'Verde', C: 'Incoloro' };
+    return map[color.toUpperCase()] || 'Desconocido';
+  }
+
+  getRemainingToughness(card: any, player: any): number {
+    const baseT = parseInt(card.toughness || '0', 10);
+    const d = card.damageTaken || 0;
+    return baseT - d; // Simplified since we don't have engine modifications here
+  }
+
+  getCardById(id: string): any {
+    return this.opponent?.field?.find((c: any) => c.id === id) || this.me?.field?.find((c: any) => c.id === id);
+  }
+
+  goToMenu(): void {
+    this.router.navigate(['/home']);
+  }
+
+  // Disable interactions
+  showVictoryModal = false;
+  engine: any = {
+    getIsProcessing: () => false,
+    targetPlayer: (id: string) => {},
+    getModifiedPower: (card: any, player: any) => parseInt(card.power || '0', 10),
+    payGenericMana: (key: any) => {},
+    cancelPayment: () => {},
+    resolveManaChoice: (color: string) => {},
+    autoPayGeneric: () => {}
+  };
+
+  onPassPriority(): void {}
+  onPlayCard(cardId: string): void {}
+  onMulligan(): void {}
+  onKeep(): void {}
+  onTapCard(cardId: string): void {}
+  onConcede(): void {}
+  toggleBlockerOrderSelection(id: string): void {}
+  submitBlockerOrder(): void {}
+  isBlockerSelected(id: string): boolean { return false; }
+  getBlockerSelectionIndex(id: string): number { return -1; }
+  isBlockerOrderComplete(): boolean { return false; }
+
+  private processStateChanges(state: any): void {
+    if (!state) return;
+
+    const currentField = [...(state.player1?.field || []), ...(state.player2?.field || [])];
+    const currentIds = new Set(currentField.map(c => c.id));
+
+    // 1. Detect Hits
+    currentField.forEach(card => {
+      const currentDamage = card.damageTaken || 0;
+      const prevDamage = this.prevDamageMap.get(card.id) || 0;
+      if (currentDamage > prevDamage) {
+        this.triggerHit(card.id, currentDamage - prevDamage);
+      }
+      this.prevDamageMap.set(card.id, currentDamage);
+    });
+
+    // 2. Detect Deaths (was in field, now is in graveyard)
+    const p1GraveIds = new Set((state.player1?.graveyard || []).map((c: any) => c.id));
+    const p2GraveIds = new Set((state.player2?.graveyard || []).map((c: any) => c.id));
+
+    this.prevFieldIds.forEach(id => {
+      if (!currentIds.has(id)) {
+        if (p1GraveIds.has(id)) {
+          const deadCard = state.player1.graveyard.find((c: any) => c.id === id);
+          if (deadCard) this.triggerDeath(deadCard, state.player1.id);
+        } else if (p2GraveIds.has(id)) {
+          const deadCard = state.player2.graveyard.find((c: any) => c.id === id);
+          if (deadCard) this.triggerDeath(deadCard, state.player2.id);
+        }
+      }
+    });
+
+    this.prevFieldIds = currentIds;
+  }
+
+  private triggerHit(cardId: string, amount: number): void {
+    this.hittingCards.add(cardId);
+    this.lastDamageTaken.set(cardId, amount);
+    setTimeout(() => {
+      this.hittingCards.delete(cardId);
+      this.lastDamageTaken.delete(cardId);
+      this.cdr.detectChanges();
+    }, 600);
+  }
+
+  private triggerDeath(card: any, ownerId: string): void {
+    if (this.dyingCards.find(c => c.id === card.id)) return;
+    
+    this.dyingCards.push({ ...card, ownerId });
+    setTimeout(() => {
+      this.dyingCards = this.dyingCards.filter(c => c.id !== card.id);
+      this.cdr.detectChanges();
+    }, 850);
+  }
+
+  isHitting(cardId: string): boolean {
+    return this.hittingCards.has(cardId);
+  }
+
+  getRecentDamage(cardId: string): number {
+    return this.lastDamageTaken.get(cardId) || 0;
+  }
+}

--- a/frontend/src/app/shared/components/friends-list/friends-list.component.html
+++ b/frontend/src/app/shared/components/friends-list/friends-list.component.html
@@ -124,6 +124,16 @@
 
                 <!-- Actions (visible on hover) -->
                 <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                  @if (activeMatchIds[friend.id]) {
+                    <button
+                      type="button"
+                      (click)="spectateMatch(activeMatchIds[friend.id], friend.id, $event)"
+                      class="p-1.5 rounded-lg bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 hover:text-orange-300 transition-all animate-pulse shadow-[0_0_8px_rgba(249,115,22,0.4)]"
+                      title="Espectar partida"
+                    >
+                      <span class="material-symbols-outlined text-base">visibility</span>
+                    </button>
+                  }
                   <button
                     type="button"
                     [routerLink]="['/profile', friend.id]"

--- a/frontend/src/app/shared/components/friends-list/friends-list.component.ts
+++ b/frontend/src/app/shared/components/friends-list/friends-list.component.ts
@@ -1,11 +1,12 @@
 import { Component, OnInit, ViewChild, ElementRef, inject, HostListener, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { RouterLink, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { UserService } from '../../../core/services/user.service';
 import { FriendshipService } from '../../../core/services/friendship.service';
 import { BlockService } from '../../../core/services/block.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { MatchService } from '../../../core/services/match.service';
 
 interface Friend {
   id: number;
@@ -43,10 +44,39 @@ export class FriendsListComponent implements OnInit {
   private readonly friendshipService = inject(FriendshipService);
   private readonly blockService = inject(BlockService);
   private readonly toastService = inject(ToastService);
+  private readonly matchService = inject(MatchService);
+  private readonly router = inject(Router);
+
+  activeMatchIds: Record<number, string> = {};
 
   ngOnInit() {
     this.loadFriends();
     this.loadBlockedUsers();
+    // Poll active matches periodically
+    setInterval(() => this.loadActiveMatches(), 5000);
+  }
+
+  loadActiveMatches() {
+    if (!this.userService.getStoredUser()?.id) return;
+    this.matchService.getActiveFriendsMatches().subscribe({
+      next: (matches: any[]) => {
+        const newActiveMatches: Record<number, string> = {};
+        for (const match of matches) {
+          // Si tenemos que matchear por username porque MatchHistoryDto tiene PlayerDto(username, avatarUrl)
+          // Necesitamos encontrar el amigo correspondiente.
+          // Wait, MatchHistoryDto en backend devuelve el username del player1 y player2.
+          const p1 = this.friends.find(f => f.username === match.player1.username);
+          if (p1) newActiveMatches[p1.id] = match.id.toString();
+          
+          if (match.player2) {
+            const p2 = this.friends.find(f => f.username === match.player2.username);
+            if (p2) newActiveMatches[p2.id] = match.id.toString();
+          }
+        }
+        this.activeMatchIds = newActiveMatches;
+      },
+      error: () => {} // silent fail for polling
+    });
   }
 
   loadFriends() {
@@ -63,6 +93,7 @@ export class FriendsListComponent implements OnInit {
       next: (friends) => {
         this.friends = friends;
         this.separateOnlineOffline();
+        this.loadActiveMatches(); // fetch matches right after friends load
         this.isLoading = false;
       },
       error: (err) => {
@@ -136,6 +167,12 @@ export class FriendsListComponent implements OnInit {
     event.stopPropagation();
     this.selectFriend(friend);
     // El parent component (MainLayout) manejará la apertura del chat
+  }
+
+  spectateMatch(matchId: string, friendId: number, event: MouseEvent) {
+    event.stopPropagation();
+    this.isDropdownOpen = false;
+    this.router.navigate(['/spectator', matchId], { queryParams: { friendId } });
   }
 
   blockUser(friend: Friend, event: MouseEvent) {


### PR DESCRIPTION
 Se ha implementado la funcionalidad para poder observar las partidas activas de los amigos en tiempo real:

Backend (MatchController & BattleController): Se ha añadido un endpoint para recuperar las partidas activas de la lista de amigos (/friends/active) y otro dedicado a devolver el estado público de la partida (/spectate/{matchId}), respetando la visibilidad de los datos (ocultando manos privadas si aplica).
Frontend (SpectatorComponent): Se ha creado un nuevo componente independiente que consume el estado de la partida mediante Long Polling (cada 2 segundos) para refrescar el tablero dinámicamente.
UI (friends-list.component): Se ha añadido un botón interactivo (ojo parpadeante) en la lista de amistades confirmadas que aparece únicamente cuando el amigo está actualmente en una partida, redirigiendo directamente a la vista de espectador.


Arreglo del Servidor de Correo (SMTP) Se ha migrado la configuración del correo en application.properties y docker-compose.yml para soportar Brevo (Sendinblue) en lugar de Gmail, solucionando los errores 500 por límites de envíos diarios excedidos a la hora de confirmar los registros de usuario.

Closes #137 